### PR TITLE
Remove masked comparison and mix intrinsics

### DIFF
--- a/include/llvm/IR/IntrinsicsNyuzi.td
+++ b/include/llvm/IR/IntrinsicsNyuzi.td
@@ -29,10 +29,10 @@ def int_nyuzi_gather_loadi : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty],
 def int_nyuzi_gather_loadf : Intrinsic<[llvm_v16f32_ty], [llvm_v16i32_ty],
 	[IntrReadMem], "llvm.nyuzi.__builtin_nyuzi_gather_loadf">;
 
-def int_nyuzi_gather_loadi_masked : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty],
+def int_nyuzi_gather_loadi_masked : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i1_ty],
 	[IntrReadMem], "llvm.nyuzi.__builtin_nyuzi_gather_loadi_masked">;
 
-def int_nyuzi_gather_loadf_masked : Intrinsic<[llvm_v16f32_ty], [llvm_v16i32_ty, llvm_i32_ty],
+def int_nyuzi_gather_loadf_masked : Intrinsic<[llvm_v16f32_ty], [llvm_v16i32_ty, llvm_v16i1_ty],
 	[IntrReadMem], "llvm.nyuzi.__builtin_nyuzi_gather_loadf_masked">;
 
 def int_nyuzi_scatter_storei : Intrinsic<[], [llvm_v16i32_ty, llvm_v16i32_ty],
@@ -41,30 +41,23 @@ def int_nyuzi_scatter_storei : Intrinsic<[], [llvm_v16i32_ty, llvm_v16i32_ty],
 def int_nyuzi_scatter_storef : Intrinsic<[], [llvm_v16i32_ty, llvm_v16f32_ty],
 	[IntrWriteMem], "llvm.nyuzi.__builtin_nyuzi_scatter_storef">;
 
-def int_nyuzi_scatter_storei_masked : Intrinsic<[], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty],
+def int_nyuzi_scatter_storei_masked : Intrinsic<[], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_v16i1_ty],
 	[IntrWriteMem], "llvm.nyuzi.__builtin_nyuzi_scatter_storei_masked">;
 
-def int_nyuzi_scatter_storef_masked : Intrinsic<[], [llvm_v16i32_ty, llvm_v16f32_ty, llvm_i32_ty],
+def int_nyuzi_scatter_storef_masked : Intrinsic<[], [llvm_v16i32_ty, llvm_v16f32_ty, llvm_v16i1_ty],
 	[IntrWriteMem], "llvm.nyuzi.__builtin_nyuzi_scatter_storef_masked">;
 
-def int_nyuzi_block_loadi_masked : Intrinsic<[llvm_v16i32_ty], [v16i32_ptr_ty, llvm_i32_ty],
+def int_nyuzi_block_loadi_masked : Intrinsic<[llvm_v16i32_ty], [v16i32_ptr_ty, llvm_v16i1_ty],
 	[IntrReadMem, IntrArgMemOnly], "llvm.nyuzi.__builtin_nyuzi_block_loadi_masked">;
 
-def int_nyuzi_block_loadf_masked : Intrinsic<[llvm_v16f32_ty], [v16i32_ptr_ty, llvm_i32_ty],
+def int_nyuzi_block_loadf_masked : Intrinsic<[llvm_v16f32_ty], [v16i32_ptr_ty, llvm_v16i1_ty],
 	[IntrReadMem, IntrArgMemOnly], "llvm.nyuzi.__builtin_nyuzi_block_loadf_masked">;
 
-def int_nyuzi_block_storei_masked : Intrinsic<[], [v16i32_ptr_ty, llvm_v16i32_ty, llvm_i32_ty],
-	[IntrWriteMem, IntrArgMemOnly], "llvm.nyuzi.__builtin_nyuzi_block_storei_masked">;
+def int_nyuzi_block_storei_masked : Intrinsic<[], [v16i32_ptr_ty, llvm_v16i32_ty, llvm_v16i1_ty],
+	[IntrWriteMem, IntrArgMemOnly],   "llvm.nyuzi.__builtin_nyuzi_block_storei_masked">;
 
-def int_nyuzi_block_storef_masked : Intrinsic<[], [v16i32_ptr_ty, llvm_v16f32_ty, llvm_i32_ty],
+def int_nyuzi_block_storef_masked : Intrinsic<[], [v16i32_ptr_ty, llvm_v16f32_ty, llvm_v16i1_ty],
 	[IntrWriteMem, IntrArgMemOnly], "llvm.nyuzi.__builtin_nyuzi_block_storef_masked">;
-
-// The blend pattern is a pseudo-instruction used to encode masked operations
-def int_nyuzi_vector_mixi : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_v16i32_ty,
-	llvm_v16i32_ty], [IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_vector_mixi">;
-
-def int_nyuzi_vector_mixf : Intrinsic<[llvm_v16f32_ty], [llvm_i32_ty, llvm_v16f32_ty,
-	llvm_v16f32_ty], [IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_vector_mixf">;
 
 // Shuffle vector elements
 def int_nyuzi_shufflei : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
@@ -72,53 +65,8 @@ def int_nyuzi_shufflei : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i3
 def int_nyuzi_shufflef : Intrinsic<[llvm_v16f32_ty], [llvm_v16f32_ty, llvm_v16i32_ty],
 	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_shufflef">;
 
-// Vector Comparisions
-def int_nyuzi_mask_cmpi_ugt : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ugt">;
 
-def int_nyuzi_mask_cmpi_uge : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_uge">;
 
-def int_nyuzi_mask_cmpi_ult : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ult">;
 
-def int_nyuzi_mask_cmpi_ule : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ule">;
-
-def int_nyuzi_mask_cmpi_sgt : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sgt">;
-
-def int_nyuzi_mask_cmpi_sge : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sge">;
-
-def int_nyuzi_mask_cmpi_slt : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_slt">;
-
-def int_nyuzi_mask_cmpi_sle : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sle">;
-
-def int_nyuzi_mask_cmpi_eq : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem, Commutative], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_eq">;
-
-def int_nyuzi_mask_cmpi_ne : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty],
-	[IntrNoMem, Commutative], "llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ne">;
-
-def int_nyuzi_mask_cmpf_gt : Intrinsic<[llvm_i32_ty], [llvm_v16f32_ty, llvm_v16f32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpf_gt">;
-
-def int_nyuzi_mask_cmpf_ge : Intrinsic<[llvm_i32_ty], [llvm_v16f32_ty, llvm_v16f32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpf_ge">;
-
-def int_nyuzi_mask_cmpf_le : Intrinsic<[llvm_i32_ty], [llvm_v16f32_ty, llvm_v16f32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpf_le">;
-
-def int_nyuzi_mask_cmpf_lt : Intrinsic<[llvm_i32_ty], [llvm_v16f32_ty, llvm_v16f32_ty],
-	[IntrNoMem], "llvm.nyuzi.__builtin_nyuzi_mask_cmpf_lt">;
-
-def int_nyuzi_mask_cmpf_eq : Intrinsic<[llvm_i32_ty], [llvm_v16f32_ty, llvm_v16f32_ty],
-	[IntrNoMem, Commutative], "llvm.nyuzi.__builtin_nyuzi_mask_cmpf_eq">;
-
-def int_nyuzi_mask_cmpf_ne : Intrinsic<[llvm_i32_ty], [llvm_v16f32_ty, llvm_v16f32_ty],
-	[IntrNoMem, Commutative], "llvm.nyuzi.__builtin_nyuzi_mask_cmpf_ne">;
 }
 

--- a/lib/Target/Nyuzi/NyuziCallingConv.td
+++ b/lib/Target/Nyuzi/NyuziCallingConv.td
@@ -15,20 +15,21 @@ def CC_Nyuzi32 : CallingConv<[
   CCIfType<[i8, i16], CCPromoteToType<i32>>,
 
   // i32 f32 arguments get passed in integer registers if there is space.
-  CCIfNotVarArg<CCIfType<[i32, f32], CCAssignToReg<[S0, S1, S2, S3, S4, S5, S6, S7]>>>,
+  CCIfNotVarArg<CCIfType<[i32, f32, v16i1], CCAssignToReg<[S0, S1, S2, S3, S4, S5, S6, S7]>>>,
 
   // Vector arguments can be passed in their own registers, as above
   CCIfNotVarArg<CCIfType<[v16i32, v16f32], CCAssignToReg<[V0, V1, V2, V3, V4, V5, V6, V7]>>>,
 
   // Stick remaining registers onto stack, aligned by size
   CCIfType<[i32, f32], CCAssignToStack<4, 4>>,
-  CCIfType<[v16i32, v16f32], CCAssignToStack<64, 64>>
+  CCIfType<[v16i32, v16f32], CCAssignToStack<64, 64>>,
+  CCIfType<[v16i1], CCAssignToStack<2, 2>>
 ]>;
 
 def RetCC_Nyuzi32 : CallingConv<[
   CCIfType<[i8, i16], CCPromoteToType<i32>>,
 
-  CCIfType<[i32, f32], CCAssignToReg<[S0, S1, S2, S3, S4, S5]>>,
+  CCIfType<[i32, f32, v16i1], CCAssignToReg<[S0, S1, S2, S3, S4, S5]>>,
 
   CCIfType<[v16i32, v16f32], CCAssignToReg<[V0, V1, V2, V3, V4, V5]>>
 ]>;

--- a/lib/Target/Nyuzi/NyuziISelLowering.h
+++ b/lib/Target/Nyuzi/NyuziISelLowering.h
@@ -22,7 +22,7 @@ namespace llvm {
 class NyuziSubtarget;
 
 namespace NyuziISD {
-enum {
+enum NodeType {
   FIRST_NUMBER = ISD::BUILTIN_OP_END,
   CALL,
   RET_FLAG, // Return with a flag operand.
@@ -31,6 +31,15 @@ enum {
   RECIPROCAL_EST,
   BR_JT,
   JT_WRAPPER,
+  MASK_TO_INT,
+  MASK_FROM_INT,
+  // Float comparisons, see LowerSETCC
+  FGT,
+  FGE,
+  FLT,
+  FLE,
+  FEQ,
+  FNE,
 };
 }
 
@@ -74,6 +83,7 @@ private:
   SDValue LowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerINSERT_VECTOR_ELT(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerEXTRACT_VECTOR_ELT(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSCALAR_TO_VECTOR(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSELECT_CC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSETCC(SDValue Op, SelectionDAG &DAG) const;
@@ -90,7 +100,9 @@ private:
   SDValue LowerUINT_TO_FP(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFRAMEADDR(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerRETURNADDR(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerSIGN_EXTEND_INREG(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerSIGN_EXTEND(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerZERO_EXTEND(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerTRUNCATE(SDValue Op, SelectionDAG &DAG) const;
   MachineBasicBlock *EmitSelectCC(MachineInstr &MI,
                                   MachineBasicBlock *BB) const;
   MachineBasicBlock *EmitAtomicBinary(MachineInstr &MI, MachineBasicBlock *BB,

--- a/lib/Target/Nyuzi/NyuziInstrFormats.td
+++ b/lib/Target/Nyuzi/NyuziInstrFormats.td
@@ -27,6 +27,13 @@ def wrapper : SDNode<"NyuziISD::WRAPPER", SDTIntUnaryOp>;
 def reciprocal : SDNode<"NyuziISD::RECIPROCAL_EST", SDTFPUnaryOp>;
 def jtwrapper : SDNode<"NyuziISD::JT_WRAPPER", SDTIntUnaryOp>;
 
+// Nop conversions between i1 vectors and integers.
+// Mapped to pseudo instructions because ISel doesn't like type punning in patterns.
+def mask_to_int : SDNode<"NyuziISD::MASK_TO_INT", SDTypeProfile<1, 1,
+  [SDTCisVT<0, i32>, SDTCisVT<1, v16i1>]>>;
+def mask_from_int : SDNode<"NyuziISD::MASK_FROM_INT", SDTypeProfile<1, 1,
+  [SDTCisVT<0, v16i1>, SDTCisVT<1, i32>]>>;
+
 def SDT_BRJT : SDTypeProfile<0, 2, [SDTCisPtrTy<0>, SDTCisVT<1, i32>]>;
 def brjt : SDNode<"NyuziISD::BR_JT", SDT_BRJT, [SDNPHasChain]>;
 
@@ -328,7 +335,7 @@ multiclass TwoOpIntArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, VR512:$src1, VR512:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src1, $src2",
-      [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (OpNode v16i32:$src1, v16i32:$src2), v16i32:$oldvalue))],
+      [(set v16i32:$dest, (vselect v16i1:$mask, (OpNode v16i32:$src1, v16i32:$src2), v16i32:$oldvalue))],
       opcode,
       FmtR_VVVM,
       II_INT>;
@@ -338,7 +345,7 @@ multiclass TwoOpIntArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, VR512:$src1, GPR32:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src1, $src2",
-      [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (OpNode v16i32:$src1, (splat i32:$src2)), v16i32:$oldvalue))],
+      [(set v16i32:$dest, (vselect v16i1:$mask, (OpNode v16i32:$src1, (splat i32:$src2)), v16i32:$oldvalue))],
       opcode,
       FmtR_VVSM,
       II_INT>;
@@ -381,7 +388,7 @@ multiclass TwoOpIntArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, VR512:$src1, SIMM8OP:$imm, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src1, $imm",
-      [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (OpNode v16i32:$src1, (splat simm8:$imm)), v16i32:$oldvalue))],
+      [(set v16i32:$dest, (vselect v16i1:$mask, (OpNode v16i32:$src1, (splat simm8:$imm)), v16i32:$oldvalue))],
       opcode{4-0},
       FmtI_VVM,
       II_INT>;
@@ -391,7 +398,7 @@ multiclass TwoOpIntArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, GPR32:$src1, SIMM8OP:$imm, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src1, $imm",
-      [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (OpNode (splat i32:$src1), (splat simm8:$imm)), v16i32:$oldvalue))],
+      [(set v16i32:$dest, (vselect v16i1:$mask, (OpNode (splat i32:$src1), (splat simm8:$imm)), v16i32:$oldvalue))],
       opcode{4-0},
       FmtI_VSM,
       II_INT>;
@@ -436,7 +443,7 @@ multiclass TwoOpFloatArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, VR512:$src1, VR512:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src1, $src2",
-      [(set VR512:$dest, (int_nyuzi_vector_mixf i32:$mask, (OpNode v16f32:$src1,
+      [(set VR512:$dest, (vselect v16i1:$mask, (OpNode v16f32:$src1,
         v16f32:$src2), v16f32:$oldvalue))],
       opcode,
       FmtR_VVVM,
@@ -447,7 +454,7 @@ multiclass TwoOpFloatArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, VR512:$src1, GPR32:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src1, $src2",
-      [(set v16f32:$dest, (int_nyuzi_vector_mixf i32:$mask, (OpNode v16f32:$src1,
+      [(set v16f32:$dest, (vselect v16i1:$mask, (OpNode v16f32:$src1,
         (splat f32:$src2)), v16f32:$oldvalue))],
       opcode,
       FmtR_VVSM,
@@ -489,7 +496,7 @@ multiclass OneOpIntArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, VR512:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src2",
-      [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (OpNode v16i32:$src2),
+      [(set v16i32:$dest, (vselect v16i1:$mask, (OpNode v16i32:$src2),
         v16i32:$oldvalue))],
       opcode,
       FmtR_VVVM,
@@ -499,7 +506,7 @@ multiclass OneOpIntArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, GPR32:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src2",
-      [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (OpNode (splat i32:$src2)),
+      [(set v16i32:$dest, (vselect v16i1:$mask, (OpNode (splat i32:$src2)),
         v16i32:$oldvalue))],
       opcode,
       FmtR_VVSM,
@@ -541,7 +548,7 @@ multiclass OneOpFloatArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, VR512:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src2",
-      [(set v16f32:$dest, (int_nyuzi_vector_mixf i32:$mask, (OpNode v16f32:$src2),
+      [(set v16f32:$dest, (vselect v16i1:$mask, (OpNode v16f32:$src2),
         v16f32:$oldvalue))],
       opcode,
       FmtR_VVVM,
@@ -551,7 +558,7 @@ multiclass OneOpFloatArith<string operator, SDNode OpNode, bits<6> opcode> {
       (outs VR512:$dest),
       (ins GPR32:$mask, GPR32:$src2, VR512:$oldvalue),
       operator # "_mask $dest, $mask, $src2",
-      [(set v16f32:$dest, (int_nyuzi_vector_mixf i32:$mask, (OpNode (splat f32:$src2)),
+      [(set v16f32:$dest, (vselect v16i1:$mask, (OpNode (splat f32:$src2)),
         v16f32:$oldvalue))],
       opcode,
       FmtR_VVSM,
@@ -560,7 +567,7 @@ multiclass OneOpFloatArith<string operator, SDNode OpNode, bits<6> opcode> {
 }
 
 multiclass IntCompareInst<string operator, CondCode condition,
-  bits<6> opcode, Intrinsic vectorIntr> {
+  bits<6> opcode> {
   // Instruction format A, integer
   def SS : FormatRUnmaskedTwoOpInst<
     (outs GPR32:$dest),
@@ -575,7 +582,7 @@ multiclass IntCompareInst<string operator, CondCode condition,
     (outs GPR32:$dest),
     (ins VR512:$src1, VR512:$src2),
     operator # " $dest, $src1, $src2",
-    [(set i32:$dest, (vectorIntr v16i32:$src1, v16i32:$src2))],
+    [(set v16i1:$dest, (setcc v16i32:$src1, v16i32:$src2, condition))],
     opcode,
     FmtR_VVV,
     II_INT>;
@@ -584,7 +591,7 @@ multiclass IntCompareInst<string operator, CondCode condition,
     (outs GPR32:$dest),
     (ins VR512:$src1, GPR32:$src2),
     operator # " $dest, $src1, $src2",
-    [(set i32:$dest, (vectorIntr v16i32:$src1, (splat i32:$src2)))],
+    [(set v16i1:$dest, (setcc v16i32:$src1, (splat i32:$src2), condition))],
     opcode,
     FmtR_VVS,
     II_INT>;
@@ -603,19 +610,18 @@ multiclass IntCompareInst<string operator, CondCode condition,
     (outs GPR32:$dest),
     (ins VR512:$src1, SIMM13OP:$imm),
     operator # " $dest, $src1, $imm",
-    [(set i32:$dest, (vectorIntr v16i32:$src1, (splat simm13:$imm)))],
+    [(set v16i1:$dest, (setcc v16i32:$src1, (splat simm13:$imm), condition))],
     opcode{4-0},
     FmtI_VV,
     II_INT>;
 }
 
-multiclass FloatCompareInst<string operator, CondCode condition, bits<6> opcode,
-  Intrinsic vectorIntr> {
+multiclass FloatCompareInst<string operator, SDNode OpNode, bits<6> opcode> {
   def SS : FormatRUnmaskedTwoOpInst<
     (outs GPR32:$dest),
     (ins GPR32:$src1, GPR32:$src2),
     operator # "_f $dest, $src1, $src2",
-    [(set i32:$dest, (setcc f32:$src1, f32:$src2, condition))],
+    [(set i32:$dest, (OpNode f32:$src1, f32:$src2))],
     opcode,
     FmtR_SSS,
     II_FLOAT>;
@@ -624,7 +630,7 @@ multiclass FloatCompareInst<string operator, CondCode condition, bits<6> opcode,
     (outs GPR32:$dest),
     (ins VR512:$src1, VR512:$src2),
     operator # "_f $dest, $src1, $src2",
-    [(set i32:$dest, (vectorIntr v16f32:$src1, v16f32:$src2))],
+    [(set v16i1:$dest, (OpNode v16f32:$src1, v16f32:$src2))],
     opcode,
     FmtR_VVV,
     II_FLOAT>;
@@ -633,11 +639,12 @@ multiclass FloatCompareInst<string operator, CondCode condition, bits<6> opcode,
     (outs GPR32:$dest),
     (ins VR512:$src1, GPR32:$src2),
     operator # "_f $dest, $src1, $src2",
-    [(set i32:$dest, (vectorIntr v16f32:$src1, (splat f32:$src2)))],
+    [(set v16i1:$dest, (OpNode v16f32:$src1, (splat f32:$src2)))],
     opcode,
     FmtR_VVS,
     II_FLOAT>;
 }
+
 
 //////////////////////////////////////////////////////////////////
 // Format M: Memory instructions

--- a/lib/Target/Nyuzi/NyuziInstrInfo.td
+++ b/lib/Target/Nyuzi/NyuziInstrInfo.td
@@ -110,23 +110,46 @@ def FTOSIVS : FormatRUnmaskedOneOpInst<
   FmtR_VVS,
   II_FLOAT>;
 
-defm SGTSI : IntCompareInst<"cmpgt_i", SETGT, 0x12, int_nyuzi_mask_cmpi_sgt>;
-defm SGESI : IntCompareInst<"cmpge_i", SETGE, 0x13, int_nyuzi_mask_cmpi_sge>;
-defm SLTSI : IntCompareInst<"cmplt_i", SETLT, 0x14, int_nyuzi_mask_cmpi_slt>;
-defm SLESI : IntCompareInst<"cmple_i", SETLE, 0x15, int_nyuzi_mask_cmpi_sle>;
-defm SEQSI : IntCompareInst<"cmpeq_i", SETEQ, 0x10, int_nyuzi_mask_cmpi_eq>;
-defm SNESI : IntCompareInst<"cmpne_i", SETNE, 0x11, int_nyuzi_mask_cmpi_ne>;
-defm SGTUI : IntCompareInst<"cmpgt_u", SETUGT, 0x16, int_nyuzi_mask_cmpi_ugt>;
-defm SGEUI : IntCompareInst<"cmpge_u", SETUGE, 0x17, int_nyuzi_mask_cmpi_uge>;
-defm SLTUI : IntCompareInst<"cmplt_u", SETULT, 0x18, int_nyuzi_mask_cmpi_ult>;
-defm SLEUI : IntCompareInst<"cmple_u", SETULE, 0x19, int_nyuzi_mask_cmpi_ule>;
+defm SGTSI : IntCompareInst<"cmpgt_i", SETGT, 0x12>;
+defm SGESI : IntCompareInst<"cmpge_i", SETGE, 0x13>;
+defm SLTSI : IntCompareInst<"cmplt_i", SETLT, 0x14>;
+defm SLESI : IntCompareInst<"cmple_i", SETLE, 0x15>;
+defm SEQSI : IntCompareInst<"cmpeq_i", SETEQ, 0x10>;
+defm SNESI : IntCompareInst<"cmpne_i", SETNE, 0x11>;
+defm SGTUI : IntCompareInst<"cmpgt_u", SETUGT, 0x16>;
+defm SGEUI : IntCompareInst<"cmpge_u", SETUGE, 0x17>;
+defm SLTUI : IntCompareInst<"cmplt_u", SETULT, 0x18>;
+defm SLEUI : IntCompareInst<"cmple_u", SETULE, 0x19>;
 
-defm SGTFO : FloatCompareInst<"cmpgt", SETOGT, 0x2c, int_nyuzi_mask_cmpf_gt>;
-defm SGEFO : FloatCompareInst<"cmpge", SETOGE, 0x2d, int_nyuzi_mask_cmpf_ge>;
-defm SLTFO : FloatCompareInst<"cmplt", SETOLT, 0x2e, int_nyuzi_mask_cmpf_lt>;
-defm SLEFO : FloatCompareInst<"cmple", SETOLE, 0x2f, int_nyuzi_mask_cmpf_le>;
-defm SEQFO : FloatCompareInst<"cmpeq", SETOEQ, 0x30, int_nyuzi_mask_cmpf_eq>;
-defm SNEFO : FloatCompareInst<"cmpne", SETONE, 0x31, int_nyuzi_mask_cmpf_ne>;
+// Float comparisons are lowered to custom SDNodes so that unsupported
+// comparisons can be turned into legal comparisons plus some logical
+// operations, which may lead to an infinite loop
+def FloatCompareType: SDTypeProfile<1, 2, [
+  SDTCisInt<0>, SDTCisFP<1>, SDTCisSameAs<1, 2>
+]>;
+def FGT: SDNode<"NyuziISD::FGT", FloatCompareType>;
+def FGE: SDNode<"NyuziISD::FGE", FloatCompareType>;
+def FLT: SDNode<"NyuziISD::FLT", FloatCompareType>;
+def FLE: SDNode<"NyuziISD::FLE", FloatCompareType>;
+def FEQ: SDNode<"NyuziISD::FEQ", FloatCompareType>;
+def FNE: SDNode<"NyuziISD::FNE", FloatCompareType>;
+
+defm SGTFO : FloatCompareInst<"cmpgt", FGT, 0x2c>;
+defm SGEFO : FloatCompareInst<"cmpge", FGE, 0x2d>;
+defm SLTFO : FloatCompareInst<"cmplt", FLT, 0x2e>;
+defm SLEFO : FloatCompareInst<"cmple", FLE, 0x2f>;
+defm SEQFO : FloatCompareInst<"cmpeq", FEQ, 0x30>;
+defm SNEFO : FloatCompareInst<"cmpne", FNE, 0x31>;
+
+// Mask operations (register-register)
+def : Pat<(or v16i1:$src1, v16i1:$src2), (ORSSS v16i1:$src1, v16i1:$src2)>;
+def : Pat<(and v16i1:$src1, v16i1:$src2), (ANDSSS v16i1:$src1, v16i1:$src2)>;
+def : Pat<(xor v16i1:$src1, v16i1:$src2), (XORSSS v16i1:$src1, v16i1:$src2)>;
+// Mask operations (register-immediate)
+def : Pat<(or v16i1:$src1, (mask_from_int simm13:$src2)), (ORSSI v16i1:$src1, simm13:$src2)>;
+def : Pat<(and v16i1:$src1, (mask_from_int simm13:$src2)), (ANDSSI v16i1:$src1, simm13:$src2)>;
+def : Pat<(xor v16i1:$src1, (mask_from_int simm13:$src2)), (XORSSI v16i1:$src1, simm13:$src2)>;
+
 
 def GET_LANEI : FormatRUnmaskedTwoOpInst<
   (outs GPR32:$dest),
@@ -165,19 +188,20 @@ let Constraints = "$dest = $oldvalue" in {
     (outs VR512:$dest),
     (ins GPR32:$mask, VR512:$src1, VR512:$src2, VR512:$oldvalue),
     "shuffle_mask $dest, $mask, $src1, $src2",
-    [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (int_nyuzi_shufflei v16i32:$src1,
+    [(set v16i32:$dest, (vselect v16i1:$mask, (int_nyuzi_shufflei v16i32:$src1,
       v16i32:$src2), v16i32:$oldvalue))],
     0x0d,
     FmtR_VVVM,
     II_INT>;
 }
 
+
 // Floating point shuffle forms
 def : Pat<(int_nyuzi_shufflef v16f32:$src1, v16i32:$src2),
   (SHUFFLEI v16f32:$src1, v16i32:$src2)>;
-def : Pat<(int_nyuzi_vector_mixf i32:$mask, (int_nyuzi_shufflef v16f32:$src1, v16i32:$src2),
+def : Pat<(vselect v16i1:$mask, (int_nyuzi_shufflef v16f32:$src1, v16i32:$src2),
   v16f32:$oldvalue),
-  (SHUFFLEI_MASK i32:$mask, v16f32:$src1, v16i32:$src2, v16f32:$oldvalue)>;
+  (SHUFFLEI_MASK v16i1:$mask, v16f32:$src1, v16i32:$src2, v16f32:$oldvalue)>;
 
 def MOVESS : FormatRUnmaskedOneOpInst<
   (outs GPR32:$dest),
@@ -187,6 +211,11 @@ def MOVESS : FormatRUnmaskedOneOpInst<
   0xf,
   FmtR_SSS,
   II_INT>;
+
+// v16i1<->i32 type punning. Lowered to a generic COPY MachineInst,
+// which is transparent to the rest of LLVM and can be optimized.
+def : Pat<(i32 (mask_to_int v16i1:$src)), (COPY $src)>;
+def : Pat<(v16i1 (mask_from_int i32:$src)), (COPY $src)>;
 
 // This should only be invoked for types that will fit in the immediate field
 // of the instruction.  The lowering code will transform other types into
@@ -235,7 +264,7 @@ let Constraints = "$dest = $oldvalue" in {
     (outs VR512:$dest),
     (ins GPR32:$mask, VR512:$src2, VR512:$oldvalue),
     "move_mask $dest, $mask, $src2",
-    [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, v16i32:$src2, v16i32:$oldvalue))],
+    [(set v16i32:$dest, (vselect v16i1:$mask, v16i32:$src2, v16i32:$oldvalue))],
     0xf,
     FmtR_VVVM,
     II_INT>;
@@ -244,7 +273,7 @@ let Constraints = "$dest = $oldvalue" in {
     (outs VR512:$dest),
     (ins GPR32:$mask, SIMM8OP:$imm, VR512:$oldvalue),
     "move_mask $dest, $mask, $imm",
-    [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (splat imm:$imm), v16i32:$oldvalue))],  // simm8?
+    [(set v16i32:$dest, (vselect v16i1:$mask, (splat imm:$imm), v16i32:$oldvalue))],  // simm8?
     0xf,
     FmtI_VSM,
     II_INT>;
@@ -253,16 +282,16 @@ let Constraints = "$dest = $oldvalue" in {
     (outs VR512:$dest),
     (ins GPR32:$mask, GPR32:$src2, VR512:$oldvalue),
     "move_mask $dest, $mask, $src2",
-    [(set v16i32:$dest, (int_nyuzi_vector_mixi i32:$mask, (splat i32:$src2), v16i32:$oldvalue))],
+    [(set v16i32:$dest, (vselect v16i1:$mask, (splat i32:$src2), v16i32:$oldvalue))],
     0xf,
     FmtR_VVSM,
     II_INT>;
 }
 
-def : Pat<(int_nyuzi_vector_mixf i32:$mask, v16f32:$src2, v16f32:$oldvalue),
-  (MOVEVVMI i32:$mask, v16f32:$src2, v16f32:$oldvalue)>;
-def : Pat<(int_nyuzi_vector_mixf i32:$mask, (splat f32:$src2), v16f32:$oldvalue),
-  (MOVEVSMI i32:$mask, f32:$src2, v16f32:$oldvalue)>;
+def : Pat<(vselect v16i1:$mask, v16f32:$src2, v16f32:$oldvalue),
+  (MOVEVVMI v16i1:$mask, v16f32:$src2, v16f32:$oldvalue)>;
+def : Pat<(vselect v16i1:$mask, (splat f32:$src2), v16f32:$oldvalue),
+  (MOVEVSMI v16i1:$mask, f32:$src2, v16f32:$oldvalue)>;
 
 //////////////////////////////////////////////////////////////////
 // Memory Access (Format C)
@@ -295,7 +324,7 @@ let mayLoad = 1 in {
     (outs VR512:$srcDest),
     (ins MEMS10:$addr, GPR32:$mask),
     "load_v_mask $srcDest, $mask, $addr",
-    [(set v16i32:$srcDest, (int_nyuzi_block_loadi_masked ADDRri:$addr, i32:$mask))],
+    [(set v16i32:$srcDest, (int_nyuzi_block_loadi_masked ADDRri:$addr, v16i1:$mask))],
     FmtM_BlockMasked,
     1>;
 
@@ -303,15 +332,14 @@ let mayLoad = 1 in {
     (outs VR512:$srcDest),
     (ins MEMV15:$addr),
     "load_gath $srcDest, $addr",
-    [(set v16i32:$srcDest, (int_nyuzi_gather_loadi VADDRri:$addr))],
-    FmtM_ScGath,
+    [(set v16i32:$srcDest, (int_nyuzi_gather_loadi VADDRri:$addr))], FmtM_ScGath,
     1>;
 
   def INT_GATHER_LOADI_MASKED : FormatMMaskedInst<
     (outs VR512:$srcDest),
     (ins MEMV10:$addr, GPR32:$mask),
     "load_gath_mask $srcDest, $mask, $addr",
-    [(set v16i32:$srcDest, (int_nyuzi_gather_loadi_masked VADDRri:$addr, i32:$mask))],
+    [(set v16i32:$srcDest, (int_nyuzi_gather_loadi_masked VADDRri:$addr, v16i1:$mask))],
     FmtM_ScGathMasked,
     1>;
 }
@@ -322,11 +350,12 @@ def : Pat<(i32 (extloadi8 ADDRri:$addr)), (LBU ADDRri:$addr)>;
 def : Pat<(i32 (extloadi16 ADDRri:$addr)), (LSS ADDRri:$addr)>;
 def : Pat<(f32 (load ADDRri:$addr)), (LW ADDRri:$addr)>;
 def : Pat<(v16f32 (load ADDRri:$addr)), (BLOCK_LOADI ADDRri:$addr)>;
-def : Pat<(int_nyuzi_block_loadf_masked ADDRri:$addr, i32:$mask),
-  (INT_BLOCK_LOADI_MASKED ADDRri:$addr, i32:$mask)>;
+def : Pat<(int_nyuzi_block_loadf_masked ADDRri:$addr, v16i1:$mask),
+  (INT_BLOCK_LOADI_MASKED ADDRri:$addr, v16i1:$mask)>;
 def : Pat<(int_nyuzi_gather_loadf VADDRri:$addr), (INT_GATHER_LOADI VADDRri:$addr)>;
-def : Pat<(int_nyuzi_gather_loadf_masked VADDRri:$addr, i32:$mask),
-  (INT_GATHER_LOADI_MASKED VADDRri:$addr, i32:$mask)>;
+def : Pat<(int_nyuzi_gather_loadf_masked VADDRri:$addr, v16i1:$mask),
+  (INT_GATHER_LOADI_MASKED VADDRri:$addr, v16i1:$mask)>;
+def : Pat<(v16i1 (load ADDRri:$addr)), (LSU ADDRri:$addr)>;
 
 let mayStore = 1 in {
   def SB : ScalarStoreInst<"8", truncstorei8, FmtM_Byte_Signed>;
@@ -354,7 +383,7 @@ let mayStore = 1 in {
     (outs),
     (ins VR512:$srcDest, MEMS10:$addr, GPR32:$mask), // XXX needs to
     "store_v_mask $srcDest, $mask, $addr",
-    [(int_nyuzi_block_storei_masked ADDRri:$addr, v16i32:$srcDest, i32:$mask)],
+    [(int_nyuzi_block_storei_masked ADDRri:$addr, v16i32:$srcDest, v16i1:$mask)],
     FmtM_BlockMasked,
     0>;
 
@@ -370,19 +399,20 @@ let mayStore = 1 in {
     (outs),
     (ins VR512:$srcDest, MEMV10:$addr, GPR32:$mask),
     "store_scat_mask $srcDest, $mask, $addr",
-    [(int_nyuzi_scatter_storei_masked VADDRri:$addr, v16i32:$srcDest, i32:$mask)],
+    [(int_nyuzi_scatter_storei_masked VADDRri:$addr, v16i32:$srcDest, v16i1:$mask)],
     FmtM_ScGathMasked,
     0>;
 }
 
 def : Pat<(store f32:$srcDest, ADDRri:$addr), (SW f32:$srcDest, ADDRri:$addr)>;
 def : Pat<(store v16f32:$srcDest, ADDRri:$addr), (BLOCK_STOREI v16f32:$srcDest, ADDRri:$addr)>;
-def : Pat<(int_nyuzi_block_storef_masked ADDRri:$addr, v16f32:$srcDest, i32:$mask),
-  (INT_BLOCK_STOREI_MASKED v16f32:$srcDest, ADDRri:$addr, i32:$mask)>;
+def : Pat<(int_nyuzi_block_storef_masked ADDRri:$addr, v16f32:$srcDest, v16i1:$mask),
+  (INT_BLOCK_STOREI_MASKED v16f32:$srcDest, ADDRri:$addr, v16i1:$mask)>;
 def : Pat<(int_nyuzi_scatter_storef VADDRri:$addr, v16f32:$srcDest),
   (INT_SCATTER_STOREI v16f32:$srcDest, VADDRri:$addr)>;
-def : Pat<(int_nyuzi_scatter_storef_masked VADDRri:$addr, v16f32:$srcDest, i32:$mask),
-  (INT_SCATTER_STOREI_MASKED v16f32:$srcDest, VADDRri:$addr, i32:$mask)>;
+def : Pat<(int_nyuzi_scatter_storef_masked VADDRri:$addr, v16f32:$srcDest, v16i1:$mask),
+  (INT_SCATTER_STOREI_MASKED v16f32:$srcDest, VADDRri:$addr, v16i1:$mask)>;
+def : Pat<(store v16i1:$srcDest, ADDRri:$addr), (SS v16i1:$srcDest, ADDRri:$addr)>;
 
 // Atomics
 let usesCustomInserter = 1 in {

--- a/lib/Target/Nyuzi/NyuziRegisterInfo.td
+++ b/lib/Target/Nyuzi/NyuziRegisterInfo.td
@@ -30,8 +30,8 @@ let Namespace = "Nyuzi" in {
   }
 }
 
-def GPR32 : RegisterClass<"Nyuzi", [i32, f32], 32, (add (sequence "S%u", 0, 27),
-  FP_REG, SP_REG, RA_REG, PC_REG)>;
+def GPR32 : RegisterClass<"Nyuzi", [i32, f32, v16i1], 32, 
+  (add (sequence "S%u", 0, 27), FP_REG, SP_REG, RA_REG, PC_REG)>;
 
 def VR512 : RegisterClass<"Nyuzi", [v16i32, v16f32], 512, (sequence "V%u", 0, 31)>;
 

--- a/test/CodeGen/Nyuzi/branch-on-fcmp.ll
+++ b/test/CodeGen/Nyuzi/branch-on-fcmp.ll
@@ -1,0 +1,26 @@
+; RUN: llc %s -o - | FileCheck %s
+;
+; Directly branching on a fcmp negates the 16 lower bits of the comparison
+; result before branching. This is doubly bad because the constant for that
+; negation (0xffff) doesn't fit into an immediate.
+; Instead, it should just generate a compare followed by a conditional branch.
+;
+; For now this test just records this inefficency.
+; XFAIL: *
+
+target triple = "nyuzi-elf-none"
+
+define i1 @branch_on_fcmp(float %a) {
+entry:
+
+  ; CHECK: cmpgt_f [[CMP_RESULT:s[0-9]+]], s0, s1
+  ; CHECK-NEXT: b{{z|nz}} [[CMP_RESULT]]
+  %positive = fcmp ogt float %a, 0.000000e+00
+  br i1 %positive, label %return-true, label %return-false
+
+return-true:
+  ret i1 true
+
+return-false:
+  ret i1 false
+}

--- a/test/CodeGen/Nyuzi/build-v16i1.ll
+++ b/test/CodeGen/Nyuzi/build-v16i1.ll
@@ -1,0 +1,61 @@
+; RUN: llc %s -o - | FileCheck %s
+;
+; This test validates the v16i1 path of NyuziISelLowering::LowerBUILD_VECTOR,
+; mostly the conversion from constant i1 vectors into integer bitmasks.
+
+target triple = "nyuzi"
+
+; Checks that a large i1 vector is correctly mapped
+; to an i32 constant pool entry
+; CHECK: [[MASK_CP:.LCPI[0-9]+_[0-9]+]]
+; CHECK-NEXT: .long 40960 # 0xa000
+define <16 x i1> @large_literal() { ; CHECK-LABEL: large_literal:
+  ; CHECK: load_32 s0, [[MASK_CP]]
+  ; CHECK-NEXT: ret
+  ret <16 x i1> <i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 true, i1 false, i1 true>
+}
+
+; Checks that a small i1 vector is correctly mapped
+; to an i32 immediate
+define <16 x i1> @small_literal() { ; CHECK-LABEL: small_literal:
+  ; CHECK: move s0, 2053
+  ; CHECK-NEXT: ret
+  ret <16 x i1> <i1 true, i1 false, i1 true, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 true, i1 false, i1 false, i1 false, i1 false>
+}
+
+; Checks that the lowering doesn't try to get too smart about splats.
+; CHECK: [[MASK_CP:.LCPI[0-9]+_[0-9]+]]
+; CHECK-NEXT: .long 65535
+define <16 x i1> @splat() { ; CHECK-LABEL: splat:
+entry:
+  ; CHECK: load_32 s0, [[MASK_CP]]
+  ; CHECK-NEXT: ret
+  %.splatinsert = insertelement <16 x i1> undef, i1 true, i32 0
+  %.splat = shufflevector <16 x i1> %.splatinsert, <16 x i1> undef, <16 x i32> zeroinitializer
+  ret <16 x i1> %.splat
+}
+
+; Checks the undef handling
+define <16 x i1> @undef_lanes() { ; CHECK-LABEL: undef_lanes:
+entry:
+  ; CHECK: move s0, 5
+  ; CHECK-NEXT: ret
+  %0 = insertelement <16 x i1> undef, i1 true, i32 0
+  %1 = insertelement <16 x i1> %0, i1 true, i32 2
+  ret <16 x i1> %1
+}
+
+
+; Checks that non-constant BUILD_VECTOR works
+define <16 x i1> @nonconst(i1 %a, i1 %b) { ; CHECK-LABEL: nonconst:
+entry:
+  ; CHECK-NOT: load_32
+  ; CHECK: and s0, s0, 1
+  ; CHECK: and s1, s1, 1
+  ; CHECK: shl s1, s1, 8
+  ; CHECK: or s0, s1, s0
+  ; CHECK: shl s0, s0, 5
+  %0 = insertelement <16 x i1> zeroinitializer, i1 %a, i32 5
+  %1 = insertelement <16 x i1> %0, i1 %b, i32 13
+  ret <16 x i1> %1
+}

--- a/test/CodeGen/Nyuzi/extractelement.ll
+++ b/test/CodeGen/Nyuzi/extractelement.ll
@@ -36,3 +36,21 @@ define float @testfimm(<16 x float> %a, i32 %b) { ; CHECK-LABEL: testfimm:
 
   ret float %elem
 }
+
+define i1 @testmaskimm(<16 x i1> %a) { ; CHECK-LABEL: testmaskimm:
+  %elem = extractelement <16 x i1> %a, i32 9
+
+  ; CHECK: shr s0, s0, 9
+  ; CHECK: and s0, s0, 1
+
+  ret i1 %elem
+}
+
+define i1 @testmask(<16 x i1> %a, i32 %b) { ; CHECK-LABEL: testmask:
+  %elem = extractelement <16 x i1> %a, i32 %b
+
+  ; CHECK: shr s0, s0, s1
+  ; CHECK: and s0, s0, 1
+
+  ret i1 %elem
+}

--- a/test/CodeGen/Nyuzi/insertelement.ll
+++ b/test/CodeGen/Nyuzi/insertelement.ll
@@ -19,6 +19,17 @@ define <16 x i32> @test_inserti(<16 x i32> %orig, i32 %value, i32 %lane) {	; CHE
   ret <16 x i32> %result
 }
 
+define <16 x i32> @test_inserti_const(<16 x i32> %orig, i32 %value) {	; CHECK-LABEL: test_inserti_const:
+  %result = insertelement <16 x i32> %orig, i32 %value, i32 7
+
+  ; Lane is constant, so the mask should be constant folded.
+
+  ; CHECK: move [[MASKREG:s[0-9]+]], 128
+	; CHECK: move_mask v0, [[MASKREG]], s0
+
+  ret <16 x i32> %result
+}
+
 define <16 x float> @test_insertf(<16 x float> %orig, float %value, i32 %lane) { ; CHECK-LABEL: test_insertf:
   %result = insertelement <16 x float> %orig, float %value, i32 %lane
 
@@ -37,4 +48,16 @@ define <16 x i32> @test_insert_undef(i32 %a) {  ; CHECK-LABEL: test_insert_undef
   ; CHECK: move v0, s0
 
   ret <16 x i32> %result
+}
+
+; v16i1 insertions require bit manipulation
+define <16 x i1> @test_v16i1_insert(<16 x i1> %orig, i1 %a) { ; CHECK-LABEL: test_v16i1_insert
+  %result = insertelement <16 x i1> %orig, i1 %a, i32 6
+
+  ; CHECK: and s0, s0, -65
+  ; CHECK: and s1, s1, 1
+  ; CHECK: shl s1, s1, 6
+  ; CHECK: or s0, s1, s0
+
+  ret <16 x i1> %result
 }

--- a/test/CodeGen/Nyuzi/intrinsics.ll
+++ b/test/CodeGen/Nyuzi/intrinsics.ll
@@ -9,30 +9,28 @@ declare i32 @llvm.nyuzi.__builtin_nyuzi_read_control_reg(i32 %reg)
 declare void @llvm.nyuzi.__builtin_nyuzi_write_control_reg(i32 %reg, i32 %value)
 declare <16 x i32> @llvm.nyuzi.__builtin_nyuzi_gather_loadi(<16 x i32> %a)
 declare <16 x float> @llvm.nyuzi.__builtin_nyuzi_gather_loadf(<16 x i32> %a)
-declare <16 x i32> @llvm.nyuzi.__builtin_nyuzi_gather_loadi_masked(<16 x i32> %a, i32 %mask)
-declare <16 x float> @llvm.nyuzi.__builtin_nyuzi_gather_loadf_masked(<16 x i32> %a, i32 %mask)
+declare <16 x i32> @llvm.nyuzi.__builtin_nyuzi_gather_loadi_masked(<16 x i32> %a, <16 x i1> %mask)
+declare <16 x float> @llvm.nyuzi.__builtin_nyuzi_gather_loadf_masked(<16 x i32> %a, <16 x i1> %mask)
 declare void @llvm.nyuzi.__builtin_nyuzi_scatter_storei(<16 x i32> %ptr,
   <16 x i32> %value)
 declare void @llvm.nyuzi.__builtin_nyuzi_scatter_storef(<16 x i32> %ptr,
   <16 x float> %value)
 declare void @llvm.nyuzi.__builtin_nyuzi_scatter_storei_masked(<16 x i32> %ptr,
-  <16 x i32> %value, i32 %mask)
+  <16 x i32> %value, <16 x i1> %mask)
 declare void @llvm.nyuzi.__builtin_nyuzi_scatter_storef_masked(<16 x i32> %ptr,
-  <16 x float> %value, i32 %mask)
+  <16 x float> %value, <16 x i1> %mask)
 declare <16 x i32> @llvm.nyuzi.__builtin_nyuzi_block_loadi_masked(<16 x i32>* %ptr,
-  i32 %mask)
+  <16 x i1> %mask)
 declare <16 x float> @llvm.nyuzi.__builtin_nyuzi_block_loadf_masked(<16 x i32>* %ptr,
-  i32 %mask)
+  <16 x i1> %mask)
 declare void @llvm.nyuzi.__builtin_nyuzi_block_storei_masked(<16 x i32>* %ptr,
-  <16 x i32> %value, i32 %mask)
+  <16 x i32> %value, <16 x i1> %mask)
 declare void @llvm.nyuzi.__builtin_nyuzi_block_storef_masked(<16 x i32>* %ptr,
-  <16 x float> %value, i32 %mask)
+  <16 x float> %value, <16 x i1> %mask)
 declare i32 @llvm.ctlz.i32(i32 %val)
 declare i32 @llvm.cttz.i32(i32 %val)
 declare <16 x i32> @llvm.nyuzi.__builtin_nyuzi_shufflei(<16 x i32> %a, <16 x i32> %b)
 declare <16 x float> @llvm.nyuzi.__builtin_nyuzi_shufflef(<16 x float> %a, <16 x i32> %b)
-declare <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %a, <16 x i32> %b)
-declare <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %a, <16 x float> %b)
 
 define i32 @get_control_reg() { ; CHECK-LABEL: get_control_reg:
   %1 = call i32 @llvm.nyuzi.__builtin_nyuzi_read_control_reg(i32 7)
@@ -66,16 +64,16 @@ define <16 x float> @gather_loadf(<16 x i32> %ptr) { ; CHECK-LABEL: gather_loadf
   ret <16 x float> %1
 }
 
-define <16 x i32> @gather_loadi_masked(<16 x i32> %ptr, i32 %mask) { ; CHECK-LABEL: gather_loadi_masked:
-  %1 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_gather_loadi_masked(<16 x i32> %ptr, i32 %mask)
+define <16 x i32> @gather_loadi_masked(<16 x i32> %ptr, <16 x i1> %mask) { ; CHECK-LABEL: gather_loadi_masked:
+  %1 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_gather_loadi_masked(<16 x i32> %ptr, <16 x i1> %mask)
 
   ; CHECK: load_gath_mask v0, s0, (v0)
 
   ret <16 x i32> %1
 }
 
-define <16 x float> @gather_loadf_masked(<16 x i32> %ptr, i32 %mask) { ; CHECK-LABEL: gather_loadf_masked:
-  %1 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_gather_loadf_masked(<16 x i32> %ptr, i32 %mask)
+define <16 x float> @gather_loadf_masked(<16 x i32> %ptr, <16 x i1> %mask) { ; CHECK-LABEL: gather_loadf_masked:
+  %1 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_gather_loadf_masked(<16 x i32> %ptr, <16 x i1> %mask)
 
   ; CHECK: load_gath_mask v0, s0, (v0)
 
@@ -98,52 +96,52 @@ define void @scatter_storef(<16 x i32> %ptr, <16 x float> %value) { ; CHECK-LABE
   ret void
 }
 
-define void @scatter_storei_masked(<16 x i32> %ptr, <16 x i32> %value, i32 %mask) { ; CHECK-LABEL: scatter_storei_masked:
-  call void @llvm.nyuzi.__builtin_nyuzi_scatter_storei_masked(<16 x i32> %ptr, <16 x i32> %value, i32 %mask)
+define void @scatter_storei_masked(<16 x i32> %ptr, <16 x i32> %value, <16 x i1> %mask) { ; CHECK-LABEL: scatter_storei_masked:
+  call void @llvm.nyuzi.__builtin_nyuzi_scatter_storei_masked(<16 x i32> %ptr, <16 x i32> %value, <16 x i1> %mask)
 
   ; CHECK: store_scat_mask v1, s0, (v0)
 
   ret void
 }
 
-define void @scatter_storef_masked(<16 x i32> %ptr, <16 x float> %value, i32 %mask) { ; CHECK-LABEL: scatter_storef_masked:
-  call void @llvm.nyuzi.__builtin_nyuzi_scatter_storef_masked(<16 x i32> %ptr, <16 x float> %value, i32 %mask)
+define void @scatter_storef_masked(<16 x i32> %ptr, <16 x float> %value, <16 x i1> %mask) { ; CHECK-LABEL: scatter_storef_masked:
+  call void @llvm.nyuzi.__builtin_nyuzi_scatter_storef_masked(<16 x i32> %ptr, <16 x float> %value, <16 x i1> %mask)
 
   ; CHECK: store_scat_mask v1, s0, (v0)
 
   ret void
 }
 
-define <16 x i32> @test_block_loadi_masked(<16 x i32>* %ptr, i32 %mask) { ; CHECK-LABEL: test_block_loadi_masked:
+define <16 x i32> @test_block_loadi_masked(<16 x i32>* %ptr, <16 x i1> %mask) { ; CHECK-LABEL: test_block_loadi_masked:
   %result = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_block_loadi_masked(
-    <16 x i32>* %ptr, i32 %mask)
+    <16 x i32>* %ptr, <16 x i1> %mask)
 
   ; CHECK: load_v_mask v0, s1, (s0)
 
   ret <16 x i32> %result
 }
 
-define <16 x float> @test_block_loadf_masked(<16 x i32>* %ptr, i32 %mask) { ; CHECK-LABEL: test_block_loadf_masked
+define <16 x float> @test_block_loadf_masked(<16 x i32>* %ptr, <16 x i1> %mask) { ; CHECK-LABEL: test_block_loadf_masked
   %result = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_block_loadf_masked(
-    <16 x i32>* %ptr, i32 %mask)
+    <16 x i32>* %ptr, <16 x i1> %mask)
 
   ; CHECK: load_v_mask v0, s1, (s0)
 
   ret <16 x float> %result
 }
 
-define void @test_block_storei_masked(<16 x i32>* %ptr, <16 x i32> %value, i32 %mask) { ; CHECK-LABEL: test_block_storei_masked
+define void @test_block_storei_masked(<16 x i32>* %ptr, <16 x i32> %value, <16 x i1> %mask) { ; CHECK-LABEL: test_block_storei_masked
   call void @llvm.nyuzi.__builtin_nyuzi_block_storei_masked(<16 x i32>* %ptr,
-    <16 x i32> %value, i32 %mask)
+    <16 x i32> %value, <16 x i1> %mask)
 
   ; CHECK: store_v_mask v0, s1, (s0)
 
   ret void
 }
 
-define void @test_block_storef_masked(<16 x i32>* %ptr, <16 x float> %value, i32 %mask) { ; CHECK-LABEL: test_block_storef_masked
+define void @test_block_storef_masked(<16 x i32>* %ptr, <16 x float> %value, <16 x i1> %mask) { ; CHECK-LABEL: test_block_storef_masked
   call void @llvm.nyuzi.__builtin_nyuzi_block_storef_masked(<16 x i32>* %ptr,
-    <16 x float> %value, i32 %mask)
+    <16 x float> %value, <16 x i1> %mask)
 
   ; CHECK: store_v_mask v0, s1, (s0)
 
@@ -184,18 +182,18 @@ define <16 x float> @shufflef(<16 x float> %a, <16 x i32> %b) { ; CHECK-LABEL: s
   ret <16 x float> %shuffled
 }
 
-define <16 x i32> @shufflei_mask(i32 %mask, <16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: shufflei_mask:
+define <16 x i32> @shufflei_mask(<16 x i1> %mask, <16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: shufflei_mask:
   %shuffled = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_shufflei(<16 x i32> %a, <16 x i32> %b)
-  %blended = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %shuffled, <16 x i32> %b)
+  %blended = select <16 x i1> %mask, <16 x i32> %shuffled, <16 x i32> %b
 
   ; CHECK: shuffle_mask v{{[0-9]+}}, s0, v0
 
   ret <16 x i32> %blended
 }
 
-define <16 x float> @shufflef_mask(i32 %mask, <16 x float> %a, <16 x i32> %b) { ; CHECK-LABEL: shufflef_mask:
+define <16 x float> @shufflef_mask(<16 x i1> %mask, <16 x float> %a, <16 x i32> %b) { ; CHECK-LABEL: shufflef_mask:
   %shuffled = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_shufflef(<16 x float> %a, <16 x i32> %b)
-  %blended = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %shuffled, <16 x float> %a)
+  %blended = select <16 x i1> %mask, <16 x float> %shuffled, <16 x float> %a
 
   ; CHECK: shuffle_mask v{{[0-9]+}}, s0, v0
 
@@ -204,17 +202,17 @@ define <16 x float> @shufflef_mask(i32 %mask, <16 x float> %a, <16 x i32> %b) { 
 
 ; Various mix/moves
 
-define <16 x i32> @movevvm_i(i32 %mask, <16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: movevvm_i:
-  %blended = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %a, <16 x i32> %b)
+define <16 x i32> @movevvm_i(<16 x i1> %mask, <16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: movevvm_i:
+  %blended = select <16 x i1> %mask, <16 x i32> %a, <16 x i32> %b
 
   ; CHECK: move_mask v{{[0-9]+}}, s0, v0
 
   ret <16 x i32> %blended
 }
 
-define <16 x i32> @movevIm_i(i32 %mask, <16 x i32> %a) { ; CHECK-LABEL: movevIm_i:
-  %blended = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %a,
-    <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i32> @movevIm_i(<16 x i1> %mask, <16 x i32> %a) { ; CHECK-LABEL: movevIm_i:
+  %blended = select <16 x i1> %mask, <16 x i32> %a,
+    <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
 
   ; CHECK: move [[DEST:v[0-9]+]], 27
   ; CHECK: move_mask [[DEST]], s0, v0
@@ -231,11 +229,11 @@ define <16 x i32> @movevs_i(i32 %a) { ; CHECK-LABEL: movevs_i:
   ret <16 x i32> %splat
 }
 
-define <16 x i32> @movevsm_i(i32 %mask, <16 x i32> %a, i32 %b) { ; CHECK-LABEL: movevsm_i:
+define <16 x i32> @movevsm_i(<16 x i1> %mask, <16 x i32> %a, i32 %b) { ; CHECK-LABEL: movevsm_i:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
 
-  %blended = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %a, <16 x i32> %splat)
+  %blended = select <16 x i1> %mask, <16 x i32> %a, <16 x i32> %splat
 
   ; CHECK: move [[DEST:v[0-9]+]], s1
   ; CHECK: move_mask [[DEST]], s0, v0
@@ -243,8 +241,8 @@ define <16 x i32> @movevsm_i(i32 %mask, <16 x i32> %a, i32 %b) { ; CHECK-LABEL: 
   ret <16 x i32> %blended
 }
 
-define <16 x float> @movevvm_f(i32 %mask, <16 x float> %a, <16 x float> %b) { ; CHECK-LABEL: movevvm_f:
-  %blended = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %a, <16 x float> %b)
+define <16 x float> @movevvm_f(<16 x i1> %mask, <16 x float> %a, <16 x float> %b) { ; CHECK-LABEL: movevvm_f:
+  %blended = select <16 x i1> %mask, <16 x float> %a, <16 x float> %b
 
   ; CHECK: move_mask v{{[0-9]+}}, s0, v0
 
@@ -260,11 +258,11 @@ define <16 x float> @movevs_f(float %a) { ; CHECK-LABEL: movevs_f:
   ret <16 x float> %splat
 }
 
-define <16 x float> @movevsm_f(i32 %mask, <16 x float> %a, float %b) { ; CHECK-LABEL: movevsm_f:
+define <16 x float> @movevsm_f(<16 x i1> %mask, <16 x float> %a, float %b) { ; CHECK-LABEL: movevsm_f:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
 
-  %blended = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %a, <16 x float> %splat)
+  %blended = select <16 x i1> %mask, <16 x float> %a, <16 x float> %splat
 
   ; CHECK: move [[DEST:v[0-9]+]], s1
   ; CHECK: move_mask [[DEST]], s0, v0

--- a/test/CodeGen/Nyuzi/operator_tests.ll
+++ b/test/CodeGen/Nyuzi/operator_tests.ll
@@ -7,24 +7,6 @@
 ; on them.
 
 target triple = "nyuzi"
-
-declare <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %a, <16 x i32> %b)
-declare <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %a, <16 x float> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sgt(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sge(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_slt(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sle(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_eq(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ne(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ugt(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_uge(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ult(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ule(<16 x i32> %a, <16 x i32> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_gt(<16 x float> %a, <16 x float> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_ge(<16 x float> %a, <16 x float> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_lt(<16 x float> %a, <16 x float> %b)
-declare i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_le(<16 x float> %a, <16 x float> %b)
-
 define i32 @test_orss(i32 %a, i32 %b) { ; CHECK-LABEL: test_orss:
   %1 = or i32 %a,%b
   ; CHECK: or s{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}
@@ -39,11 +21,11 @@ define <16 x i32> @test_orvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_orvs:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_orvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_orvsm:
+define <16 x i32> @test_orvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_orvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = or <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: or_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -54,9 +36,9 @@ define <16 x i32> @test_orvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: test
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_orvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_orvvm:
+define <16 x i32> @test_orvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_orvvm:
   %1 = or <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: or_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -73,9 +55,9 @@ define <16 x i32> @test_orvvI(<16 x i32> %a) { ; CHECK-LABEL: test_orvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_orvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_orvvIm:
+define <16 x i32> @test_orvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_orvvIm:
   %1 = or <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: or_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -88,11 +70,11 @@ define <16 x i32> @test_orvsI(i32 %a) { ; CHECK-LABEL: test_orvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_orvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_orvsIm:
+define <16 x i32> @test_orvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_orvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = or <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: or_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -111,11 +93,11 @@ define <16 x i32> @test_andvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_andvs
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_andvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_andvsm:
+define <16 x i32> @test_andvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_andvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = and <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: and_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -126,9 +108,9 @@ define <16 x i32> @test_andvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: tes
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_andvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_andvvm:
+define <16 x i32> @test_andvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_andvvm:
   %1 = and <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: and_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -145,9 +127,9 @@ define <16 x i32> @test_andvvI(<16 x i32> %a) { ; CHECK-LABEL: test_andvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_andvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_andvvIm:
+define <16 x i32> @test_andvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_andvvIm:
   %1 = and <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: and_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -160,11 +142,11 @@ define <16 x i32> @test_andvsI(i32 %a) { ; CHECK-LABEL: test_andvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_andvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_andvsIm:
+define <16 x i32> @test_andvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_andvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = and <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: and_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -183,11 +165,11 @@ define <16 x i32> @test_xorvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_xorvs
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_xorvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_xorvsm:
+define <16 x i32> @test_xorvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_xorvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = xor <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: xor_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -198,9 +180,9 @@ define <16 x i32> @test_xorvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: tes
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_xorvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_xorvvm:
+define <16 x i32> @test_xorvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_xorvvm:
   %1 = xor <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: xor_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -217,9 +199,9 @@ define <16 x i32> @test_xorvvI(<16 x i32> %a) { ; CHECK-LABEL: test_xorvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_xorvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_xorvvIm:
+define <16 x i32> @test_xorvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_xorvvIm:
   %1 = xor <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: xor_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -232,11 +214,11 @@ define <16 x i32> @test_xorvsI(i32 %a) { ; CHECK-LABEL: test_xorvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_xorvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_xorvsIm:
+define <16 x i32> @test_xorvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_xorvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = xor <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: xor_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -255,11 +237,11 @@ define <16 x i32> @test_addvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_addvs
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_addvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_addvsm:
+define <16 x i32> @test_addvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_addvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = add <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: add_i_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -270,9 +252,9 @@ define <16 x i32> @test_addvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: tes
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_addvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_addvvm:
+define <16 x i32> @test_addvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_addvvm:
   %1 = add <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: add_i_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -289,9 +271,9 @@ define <16 x i32> @test_addvvI(<16 x i32> %a) { ; CHECK-LABEL: test_addvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_addvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_addvvIm:
+define <16 x i32> @test_addvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_addvvIm:
   %1 = add <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: add_i_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -304,11 +286,11 @@ define <16 x i32> @test_addvsI(i32 %a) { ; CHECK-LABEL: test_addvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_addvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_addvsIm:
+define <16 x i32> @test_addvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_addvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = add <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: add_i_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -327,11 +309,11 @@ define <16 x i32> @test_subvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_subvs
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_subvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_subvsm:
+define <16 x i32> @test_subvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_subvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = sub <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: sub_i_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -342,9 +324,9 @@ define <16 x i32> @test_subvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: tes
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_subvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_subvvm:
+define <16 x i32> @test_subvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_subvvm:
   %1 = sub <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: sub_i_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -355,9 +337,9 @@ define <16 x i32> @test_subvvI(<16 x i32> %a) { ; CHECK-LABEL: test_subvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_subvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_subvvIm:
+define <16 x i32> @test_subvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_subvvIm:
   %1 = sub <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: sub_i_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -370,11 +352,11 @@ define <16 x i32> @test_subvsI(i32 %a) { ; CHECK-LABEL: test_subvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_subvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_subvsIm:
+define <16 x i32> @test_subvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_subvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = sub <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: sub_i_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -393,11 +375,11 @@ define <16 x i32> @test_ashrvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_ashr
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_ashrvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_ashrvsm:
+define <16 x i32> @test_ashrvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_ashrvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = ashr <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: ashr_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -408,9 +390,9 @@ define <16 x i32> @test_ashrvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: te
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_ashrvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_ashrvvm:
+define <16 x i32> @test_ashrvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_ashrvvm:
   %1 = ashr <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: ashr_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -427,9 +409,9 @@ define <16 x i32> @test_ashrvvI(<16 x i32> %a) { ; CHECK-LABEL: test_ashrvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_ashrvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_ashrvvIm:
+define <16 x i32> @test_ashrvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_ashrvvIm:
   %1 = ashr <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: ashr_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -442,11 +424,11 @@ define <16 x i32> @test_ashrvsI(i32 %a) { ; CHECK-LABEL: test_ashrvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_ashrvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_ashrvsIm:
+define <16 x i32> @test_ashrvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_ashrvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = ashr <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: ashr_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -465,11 +447,11 @@ define <16 x i32> @test_lshrvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_lshr
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_lshrvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_lshrvsm:
+define <16 x i32> @test_lshrvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_lshrvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = lshr <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: shr_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -480,9 +462,9 @@ define <16 x i32> @test_lshrvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: te
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_lshrvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_lshrvvm:
+define <16 x i32> @test_lshrvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_lshrvvm:
   %1 = lshr <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: shr_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -499,9 +481,9 @@ define <16 x i32> @test_lshrvvI(<16 x i32> %a) { ; CHECK-LABEL: test_lshrvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_lshrvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_lshrvvIm:
+define <16 x i32> @test_lshrvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_lshrvvIm:
   %1 = lshr <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: shr_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -514,11 +496,11 @@ define <16 x i32> @test_lshrvsI(i32 %a) { ; CHECK-LABEL: test_lshrvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_lshrvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_lshrvsIm:
+define <16 x i32> @test_lshrvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_lshrvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = lshr <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: shr_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -537,11 +519,11 @@ define <16 x i32> @test_shlvs(<16 x i32> %a, i32 %b) { ; CHECK-LABEL: test_shlvs
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_shlvsm(<16 x i32> %a, i32 %b, i32 %mask) { ; CHECK-LABEL: test_shlvsm:
+define <16 x i32> @test_shlvsm(<16 x i32> %a, i32 %b, <16 x i1> %mask) { ; CHECK-LABEL: test_shlvsm:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = shl <16 x i32> %a,%splat
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: shl_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -552,9 +534,9 @@ define <16 x i32> @test_shlvv(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LABEL: tes
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_shlvvm(<16 x i32> %a, <16 x i32> %b, i32 %mask) { ; CHECK-LABEL: test_shlvvm:
+define <16 x i32> @test_shlvvm(<16 x i32> %a, <16 x i32> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_shlvvm:
   %1 = shl <16 x i32> %a,%b
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: shl_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x i32> %2
 }
@@ -571,9 +553,9 @@ define <16 x i32> @test_shlvvI(<16 x i32> %a) { ; CHECK-LABEL: test_shlvvI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_shlvvIm(<16 x i32> %a, i32 %mask) { ; CHECK-LABEL: test_shlvvIm:
+define <16 x i32> @test_shlvvIm(<16 x i32> %a, <16 x i1> %mask) { ; CHECK-LABEL: test_shlvvIm:
   %1 = shl <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %a)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %a
   ; CHECK: shl_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -586,11 +568,11 @@ define <16 x i32> @test_shlvsI(i32 %a) { ; CHECK-LABEL: test_shlvsI:
   ret <16 x i32> %1
 }
 
-define <16 x i32> @test_shlvsIm(i32 %a, i32 %mask) { ; CHECK-LABEL: test_shlvsIm:
+define <16 x i32> @test_shlvsIm(i32 %a, <16 x i1> %mask) { ; CHECK-LABEL: test_shlvsIm:
   %single = insertelement <16 x i32> undef, i32 %a, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
   %1 = shl <16 x i32> %splat, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
-  %2 = call <16 x i32> @llvm.nyuzi.__builtin_nyuzi_vector_mixi(i32 %mask, <16 x i32> %1, <16 x i32> %splat)
+  %2 = select <16 x i1> %mask, <16 x i32> %1, <16 x i32> %splat
   ; CHECK: shl_mask v{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}, 27
   ret <16 x i32> %2
 }
@@ -609,11 +591,11 @@ define <16 x float> @test_faddvs(<16 x float> %a, float %b) { ; CHECK-LABEL: tes
   ret <16 x float> %1
 }
 
-define <16 x float> @test_faddvsm(<16 x float> %a, float %b, i32 %mask) { ; CHECK-LABEL: test_faddvsm:
+define <16 x float> @test_faddvsm(<16 x float> %a, float %b, <16 x i1> %mask) { ; CHECK-LABEL: test_faddvsm:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
   %1 = fadd <16 x float> %a,%splat
-  %2 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %1, <16 x float> %a)
+  %2 = select <16 x i1> %mask, <16 x float> %1, <16 x float> %a
   ; CHECK: add_f_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x float> %2
 }
@@ -624,9 +606,9 @@ define <16 x float> @test_faddvv(<16 x float> %a, <16 x float> %b) { ; CHECK-LAB
   ret <16 x float> %1
 }
 
-define <16 x float> @test_faddvvm(<16 x float> %a, <16 x float> %b, i32 %mask) { ; CHECK-LABEL: test_faddvvm:
+define <16 x float> @test_faddvvm(<16 x float> %a, <16 x float> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_faddvvm:
   %1 = fadd <16 x float> %a,%b
-  %2 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %1, <16 x float> %a)
+  %2 = select <16 x i1> %mask, <16 x float> %1, <16 x float> %a
   ; CHECK: add_f_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x float> %2
 }
@@ -645,11 +627,11 @@ define <16 x float> @test_fsubvs(<16 x float> %a, float %b) { ; CHECK-LABEL: tes
   ret <16 x float> %1
 }
 
-define <16 x float> @test_fsubvsm(<16 x float> %a, float %b, i32 %mask) { ; CHECK-LABEL: test_fsubvsm:
+define <16 x float> @test_fsubvsm(<16 x float> %a, float %b, <16 x i1> %mask) { ; CHECK-LABEL: test_fsubvsm:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
   %1 = fsub <16 x float> %a,%splat
-  %2 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %1, <16 x float> %a)
+  %2 = select <16 x i1> %mask, <16 x float> %1, <16 x float> %a
   ; CHECK: sub_f_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x float> %2
 }
@@ -660,9 +642,9 @@ define <16 x float> @test_fsubvv(<16 x float> %a, <16 x float> %b) { ; CHECK-LAB
   ret <16 x float> %1
 }
 
-define <16 x float> @test_fsubvvm(<16 x float> %a, <16 x float> %b, i32 %mask) { ; CHECK-LABEL: test_fsubvvm:
+define <16 x float> @test_fsubvvm(<16 x float> %a, <16 x float> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_fsubvvm:
   %1 = fsub <16 x float> %a,%b
-  %2 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %1, <16 x float> %a)
+  %2 = select <16 x i1> %mask, <16 x float> %1, <16 x float> %a
   ; CHECK: sub_f_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x float> %2
 }
@@ -681,11 +663,11 @@ define <16 x float> @test_fmulvs(<16 x float> %a, float %b) { ; CHECK-LABEL: tes
   ret <16 x float> %1
 }
 
-define <16 x float> @test_fmulvsm(<16 x float> %a, float %b, i32 %mask) { ; CHECK-LABEL: test_fmulvsm:
+define <16 x float> @test_fmulvsm(<16 x float> %a, float %b, <16 x i1> %mask) { ; CHECK-LABEL: test_fmulvsm:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
   %1 = fmul <16 x float> %a,%splat
-  %2 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %1, <16 x float> %a)
+  %2 = select <16 x i1> %mask, <16 x float> %1, <16 x float> %a
   ; CHECK: mul_f_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
   ret <16 x float> %2
 }
@@ -696,266 +678,330 @@ define <16 x float> @test_fmulvv(<16 x float> %a, <16 x float> %b) { ; CHECK-LAB
   ret <16 x float> %1
 }
 
-define <16 x float> @test_fmulvvm(<16 x float> %a, <16 x float> %b, i32 %mask) { ; CHECK-LABEL: test_fmulvvm:
+define <16 x float> @test_fmulvvm(<16 x float> %a, <16 x float> %b, <16 x i1> %mask) { ; CHECK-LABEL: test_fmulvvm:
   %1 = fmul <16 x float> %a,%b
-  %2 = call <16 x float> @llvm.nyuzi.__builtin_nyuzi_vector_mixf(i32 %mask, <16 x float> %1, <16 x float> %a)
+  %2 = select <16 x i1> %mask, <16 x float> %1, <16 x float> %a
   ; CHECK: mul_f_mask v{{[0-9]+}}, s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
   ret <16 x float> %2
 }
 
-define i32 @cmpi_sgtvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_sgtvv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sgt(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_sgtvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_sgtvv:
+  %c = icmp sgt <16 x i32> %a, %b
   ; CHECK: cmpgt_i s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sgtvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_sgtvs:
+define <16 x i1> @icmp_sgtvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_sgtvs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sgt(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp sgt <16 x i32> %a, %splat
   ; CHECK: cmpgt_i s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sgtvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_sgtvI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sgt(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_sgtvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_sgtvI:
+  %c = icmp sgt <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmpgt_i s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sgevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_sgevv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sge(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_sgevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_sgevv:
+  %c = icmp sge <16 x i32> %a, %b
   ; CHECK: cmpge_i s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sgevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_sgevs:
+define <16 x i1> @icmp_sgevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_sgevs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sge(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp sge <16 x i32> %a, %splat
   ; CHECK: cmpge_i s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sgevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_sgevI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sge(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_sgevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_sgevI:
+  %c = icmp sge <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmpge_i s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sltvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_sltvv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_slt(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_sltvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_sltvv:
+  %c = icmp slt <16 x i32> %a, %b
   ; CHECK: cmplt_i s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sltvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_sltvs:
+define <16 x i1> @icmp_sltvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_sltvs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_slt(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp slt <16 x i32> %a, %splat
   ; CHECK: cmplt_i s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_sltvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_sltvI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_slt(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_sltvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_sltvI:
+  %c = icmp slt <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmplt_i s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_slevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_slevv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sle(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_slevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_slevv:
+  %c = icmp sle <16 x i32> %a, %b
   ; CHECK: cmple_i s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_slevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_slevs:
+define <16 x i1> @icmp_slevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_slevs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sle(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp sle <16 x i32> %a, %splat
   ; CHECK: cmple_i s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_slevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_slevI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_sle(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_slevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_slevI:
+  %c = icmp sle <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmple_i s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_eqvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_eqvv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_eq(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_eqvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_eqvv:
+  %c = icmp eq <16 x i32> %a, %b
   ; CHECK: cmpeq_i s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_eqvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_eqvs:
+define <16 x i1> @icmp_eqvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_eqvs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_eq(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp eq <16 x i32> %a, %splat
   ; CHECK: cmpeq_i s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_eqvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_eqvI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_eq(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_eqvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_eqvI:
+  %c = icmp eq <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmpeq_i s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_nevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_nevv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ne(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_nevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_nevv:
+  %c = icmp ne <16 x i32> %a, %b
   ; CHECK: cmpne_i s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_nevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_nevs:
+define <16 x i1> @icmp_nevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_nevs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ne(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp ne <16 x i32> %a, %splat
   ; CHECK: cmpne_i s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_nevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_nevI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ne(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_nevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_nevI:
+  %c = icmp ne <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmpne_i s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ugtvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ugtvv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ugt(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_ugtvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ugtvv:
+  %c = icmp ugt <16 x i32> %a, %b
   ; CHECK: cmpgt_u s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ugtvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_ugtvs:
+define <16 x i1> @icmp_ugtvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_ugtvs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ugt(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp ugt <16 x i32> %a, %splat
   ; CHECK: cmpgt_u s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ugtvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ugtvI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ugt(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_ugtvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ugtvI:
+  %c = icmp ugt <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmpgt_u s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ugevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ugevv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_uge(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_ugevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ugevv:
+  %c = icmp uge <16 x i32> %a, %b
   ; CHECK: cmpge_u s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ugevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_ugevs:
+define <16 x i1> @icmp_ugevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_ugevs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_uge(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp uge <16 x i32> %a, %splat
   ; CHECK: cmpge_u s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ugevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ugevI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_uge(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_ugevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ugevI:
+  %c = icmp uge <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmpge_u s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ultvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ultvv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ult(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_ultvv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ultvv:
+  %c = icmp ult <16 x i32> %a, %b
   ; CHECK: cmplt_u s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ultvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_ultvs:
+define <16 x i1> @icmp_ultvs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_ultvs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ult(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp ult <16 x i32> %a, %splat
   ; CHECK: cmplt_u s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ultvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ultvI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ult(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_ultvI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ultvI:
+  %c = icmp ult <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmplt_u s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ulevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ulevv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ule(<16 x i32> %a, <16 x i32> %b)
+define <16 x i1> @icmp_ulevv(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ulevv:
+  %c = icmp ule <16 x i32> %a, %b
   ; CHECK: cmple_u s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ulevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: cmpi_ulevs:
+define <16 x i1> @icmp_ulevs(<16 x i32> %a, i32 %b) {	; CHECK-LABEL: icmp_ulevs:
   %single = insertelement <16 x i32> undef, i32 %b, i32 0
   %splat = shufflevector <16 x i32> %single, <16 x i32> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ule(<16 x i32> %a, <16 x i32> %splat)
+  %c = icmp ule <16 x i32> %a, %splat
   ; CHECK: cmple_u s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpi_ulevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: cmpi_ulevI:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpi_ule(<16 x i32> %a, <16 x i32> <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>)
+define <16 x i1> @icmp_ulevI(<16 x i32> %a, <16 x i32> %b) {	; CHECK-LABEL: icmp_ulevI:
+  %c = icmp ule <16 x i32> %a, <i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27>
   ; CHECK: cmple_u s{{[0-9]+}}, v{{[0-9]+}}, 27
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_gtvv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: cmpf_gtvv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_gt(<16 x float> %a, <16 x float> %b)
+define <16 x i1> @fcmp_ogtvv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_ogtvv:
+  %c = fcmp ogt <16 x float> %a, %b
   ; CHECK: cmpgt_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_gtvs(<16 x float> %a, float %b) {	; CHECK-LABEL: cmpf_gtvs:
+define <16 x i1> @fcmp_ogtvs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_ogtvs:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_gt(<16 x float> %a, <16 x float> %splat)
+  %c = fcmp ogt <16 x float> %a, %splat
   ; CHECK: cmpgt_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_gevv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: cmpf_gevv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_ge(<16 x float> %a, <16 x float> %b)
+define <16 x i1> @fcmp_ogevv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_ogevv:
+  %c = fcmp oge <16 x float> %a, %b
   ; CHECK: cmpge_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_gevs(<16 x float> %a, float %b) {	; CHECK-LABEL: cmpf_gevs:
+define <16 x i1> @fcmp_ogevs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_ogevs:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_ge(<16 x float> %a, <16 x float> %splat)
+  %c = fcmp oge <16 x float> %a, %splat
   ; CHECK: cmpge_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_ltvv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: cmpf_ltvv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_lt(<16 x float> %a, <16 x float> %b)
+define <16 x i1> @fcmp_oltvv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_oltvv:
+  %c = fcmp olt <16 x float> %a, %b
   ; CHECK: cmplt_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_ltvs(<16 x float> %a, float %b) {	; CHECK-LABEL: cmpf_ltvs:
+define <16 x i1> @fcmp_oltvs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_oltvs:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_lt(<16 x float> %a, <16 x float> %splat)
+  %c = fcmp olt <16 x float> %a, %splat
   ; CHECK: cmplt_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_levv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: cmpf_levv:
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_le(<16 x float> %a, <16 x float> %b)
+define <16 x i1> @fcmp_olevv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_olevv:
+  %c = fcmp ole <16 x float> %a, %b
   ; CHECK: cmple_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
 }
 
-define i32 @cmpf_levs(<16 x float> %a, float %b) {	; CHECK-LABEL: cmpf_levs:
+define <16 x i1> @fcmp_olevs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_olevs:
   %single = insertelement <16 x float> undef, float %b, i32 0
   %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
-  %c = call i32 @llvm.nyuzi.__builtin_nyuzi_mask_cmpf_le(<16 x float> %a, <16 x float> %splat)
+  %c = fcmp ole <16 x float> %a, %splat
   ; CHECK: cmple_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
-  ret i32 %c
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ugtvv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_ugtvv:
+  %c = fcmp ugt <16 x float> %a, %b
+  ; CHECK: cmple_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ugtvs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_ugtvs:
+  %single = insertelement <16 x float> undef, float %b, i32 0
+  %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
+  %c = fcmp ugt <16 x float> %a, %splat
+  ; CHECK: cmple_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ugevv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_ugevv:
+  %c = fcmp uge <16 x float> %a, %b
+  ; CHECK: cmplt_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ugevs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_ugevs:
+  %single = insertelement <16 x float> undef, float %b, i32 0
+  %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
+  %c = fcmp uge <16 x float> %a, %splat
+  ; CHECK: cmplt_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ultvv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_ultvv:
+  %c = fcmp ult <16 x float> %a, %b
+  ; CHECK: cmpge_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ultvs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_ultvs:
+  %single = insertelement <16 x float> undef, float %b, i32 0
+  %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
+  %c = fcmp ult <16 x float> %a, %splat
+  ; CHECK: cmpge_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ulevv(<16 x float> %a, <16 x float> %b) {	; CHECK-LABEL: fcmp_ulevv:
+  %c = fcmp ule <16 x float> %a, %b
+  ; CHECK: cmpgt_f s{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
+}
+
+define <16 x i1> @fcmp_ulevs(<16 x float> %a, float %b) {	; CHECK-LABEL: fcmp_ulevs:
+  %single = insertelement <16 x float> undef, float %b, i32 0
+  %splat = shufflevector <16 x float> %single, <16 x float> undef, <16 x i32> zeroinitializer
+  %c = fcmp ule <16 x float> %a, %splat
+  ; CHECK: cmpgt_f s{{[0-9]+}}, v{{[0-9]+}}, s{{[0-9]+}}
+  ; CHECK: xor s{{[0-9]+}}, s{{[0-9]+}}
+  ret <16 x i1> %c
 }
 

--- a/test/CodeGen/Nyuzi/setcc_shuffle.ll
+++ b/test/CodeGen/Nyuzi/setcc_shuffle.ll
@@ -11,7 +11,9 @@ define <16 x i1> @setcc_shuffle() {
   %result = shufflevector <16 x i1> %comp, <16 x i1> undef, <16 x i32> <i32 undef, i32 8, i32 10, i32 12, i32 14, i32 undef, i32 18, i32 20, i32 22, i32 24, i32 26, i32 28, i32 30, i32 0, i32 undef, i32 4>
   ret <16 x i1> %result
 
-  ; CHECK: cmplt_i s0, v0, 0
-	; CHECK: move v0, 0
-	; CHECK: move_mask v0, s0, -1
+  ; CHECK: load_v v0,
+  ; CHECK: move v1, 0
+  ; CHECK: shuffle v0, v1, v0
+  ; CHECK: and v0, v0, 1
+  ; CHECK: cmpeq_i s0, v0, 1
 }

--- a/test/CodeGen/Nyuzi/v16i1-i32-conv.ll
+++ b/test/CodeGen/Nyuzi/v16i1-i32-conv.ll
@@ -1,0 +1,40 @@
+; RUN: llc %s -o - | FileCheck %s
+;
+; Test sext, zext from v16i1 to i32 and truncate from i32 to v16i1
+;
+
+target triple = "nyuzi-elf-none"
+
+define <16 x i32> @sext(<16 x i32>, <16 x i32>) { ; CHECK-LABEL: sext:
+entry:
+  %cmp = icmp uge <16 x i32> %0, %1
+  %sext = sext <16 x i1> %cmp to <16 x i32>
+
+  ; CHECK: cmpge_u s0, v0, v1
+  ; CHECK: move v0, 0
+  ; CHECK: move_mask v0, s0, -1
+
+  ret <16 x i32> %sext
+}
+
+define <16 x i32> @zext(<16 x i32>, <16 x i32>) { ; CHECK-LABEL: zext:
+entry:
+  %cmp = icmp uge <16 x i32> %0, %1
+  %zext = zext <16 x i1> %cmp to <16 x i32>
+
+  ; CHECK: cmpge_u s0, v0, v1
+  ; CHECK: move v0, 0
+  ; CHECK: move_mask v0, s0, 1
+
+  ret <16 x i32> %zext
+}
+
+define <16 x i1> @trunc(<16 x i32>) { ; CHECK-LABEL: trunc:
+entry:
+  %trunc = trunc <16 x i32> %0 to <16 x i1>
+
+  ; CHECK: and v0, v0, 1
+  ; CHECK: cmpeq_i s0, v0, 1
+
+  ret <16 x i1> %trunc
+}

--- a/test/CodeGen/Nyuzi/v16i1-memory.ll
+++ b/test/CodeGen/Nyuzi/v16i1-memory.ll
@@ -1,0 +1,35 @@
+; RUN: llc %s -o - | FileCheck %s
+;
+; This test validates loads and stores of v16i1.
+
+target triple = "nyuzi"
+
+; Test basic loads and stores
+define <16 x i1> @replace(<16 x i1>*, <16 x i1>) { ; CHECK-LABEL: replace:
+entry:
+  %result = load <16 x i1>, <16 x i1>* %0
+  store <16 x i1> %1, <16 x i1>* %0
+
+  ; CHECK: load_u16 s2, (s0)
+  ; CHECK: store_16 s1, (s0)
+  ; CHECK: move s0, s2
+
+  ret <16 x i1> %result
+}
+
+; Test receiving parameters on the stack
+define <16 x i1> @stack_params(i32, i32, i32, i32, i32, i32, i32, i32, <16 x i1>) { ; CHECK-LABEL: stack_params:
+entry:
+	; CHECK: load_u16 s0, (sp)
+	ret <16 x i1> %8
+}
+
+; Test passing parameters on the stack
+define void @pass_stack_params() { ; CHECK-LABEL: pass_stack_params:
+entry:
+	; CHECK: move [[MASK_PARAM:s[0-9]+]], 0
+	; CHECK: store_16 [[MASK_PARAM]], (sp)
+	; CHECK: call stack_params
+	call <16 x i1> @stack_params(i32 42, i32 42, i32 42, i32 42, i32 42, i32 42, i32 42, i32 42, <16 x i1> zeroinitializer)
+	ret void
+}

--- a/test/CodeGen/Nyuzi/v16i1-ops.ll
+++ b/test/CodeGen/Nyuzi/v16i1-ops.ll
@@ -1,0 +1,19 @@
+; RUN: llc %s -o - | FileCheck %s
+;
+; This test validates ALU operations on v16i1.
+
+target triple = "nyuzi"
+
+define <16 x i1> @frobincate(<16 x i1>, <16 x i1>, <16 x i1>) { ; CHECK-LABEL: frobincate:
+entry:
+  %xor = xor <16 x i1> %0, %1
+  %and = and <16 x i1> %xor, %2
+  %bit5 = insertelement <16 x i1> zeroinitializer, i1 true, i32 5
+  %or = or <16 x i1> %and, %bit5
+
+  ; CHECK: xor s0, s0, s1
+  ; CHECK: and s0, s0, s2
+  ; CHECK: or s0, s0, 32
+
+  ret <16 x i1> %or
+}

--- a/test/CodeGen/Nyuzi/vector_shuffle.ll
+++ b/test/CodeGen/Nyuzi/vector_shuffle.ll
@@ -196,5 +196,19 @@ define <16 x i32> @test_shuffle_undef(<16 x i32> %a, <16 x i32> %b) { ; CHECK-LA
   ret <16 x i32> %res
 }
 
+; v16i1 shuffles get translated to zext -> v16i32 shuffle -> trunc
+define <16 x i1> @test_shuffle_mix_bits(<16 x i1> %a, <16 x i1> %b) { ; CHECK-LABEL: test_shuffle_mix_bits:
+  %res = shufflevector <16 x i1> %a, <16 x i1> %b, <16 x i32> < i32 31, i32 14, i32 29, i32 12, i32 27, i32 10, i32 25, i32 8, i32 23, i32 6, i32 21, i32 4, i32 19, i32 2, i32 17, i32 0 >
 
+  ; CHECK: move v0, 0
+  ; CHECK: move_mask v0, s0, 1
+  ; CHECK: load_v [[SM_SHUFFLEVEC:v[0-9]+]], .LCPI
+  ; CHECK: shuffle v0, v0, [[SM_SHUFFLEVEC]]
+  ; CHECK: load_32 [[SM_MASK:s[0-9]+]], .LCPI
+  ; CHECK: shuffle_mask {{v[0-9]+}}, [[SM_MASK]], v1, [[SM_SHUFFLEVEC]]
+  ; CHECK: and {{v[0-9]+}}, {{v[0-9]+}}, 1
+  ; CHECK: cmpeq_i s0, {{v[0-9]+}}, 1
+
+  ret <16 x i1> %res
+}
 

--- a/tools/clang/test/CodeGen/nyuzi-intrinsics.c
+++ b/tools/clang/test/CodeGen/nyuzi-intrinsics.c
@@ -3,148 +3,268 @@
 typedef int veci16_t __attribute__((ext_vector_type(16)));
 typedef float vecf16_t __attribute__((ext_vector_type(16)));
 
-int test_write_control_reg(int value)	// CHECK: test_write_control_reg:
+void test_write_control_reg(int value)  // CHECK: test_write_control_reg:
 {
-	__builtin_nyuzi_write_control_reg(5, value);
-	// CHECK: setcr s{{[0-9]+}}, 5
+  __builtin_nyuzi_write_control_reg(5, value);
+  // CHECK: setcr s{{[0-9]+}}, 5
 }
 
-int test_read_control_reg(int value)	// CHECK: test_read_control_reg:
+int test_read_control_reg(int value)  // CHECK: test_read_control_reg:
 {
-	return __builtin_nyuzi_read_control_reg(7);
-	// CHECK: getcr s{{[0-9]+}}, 7
+  return __builtin_nyuzi_read_control_reg(7);
+  // CHECK: getcr s{{[0-9]+}}, 7
 }
 
-
-veci16_t test_gatherloadi(veci16_t ptr) 	// CHECK: test_gatherloadi
+veci16_t test_mixi(int mask, veci16_t a, veci16_t b)  // CHECK: test_mixi:
 {
-	return __builtin_nyuzi_gather_loadi(ptr);
-
-	// CHECK: load_gath v{{[0-9]+}}, (v0)
+  return __builtin_nyuzi_vector_mixi(mask, a, b);
+  // CHECK: move_mask v{{[0-9]+}}, s0, v0
 }
 
-vecf16_t test_gatherloadf(veci16_t ptr) 	// CHECK: test_gatherloadf
+vecf16_t test_mixf(int mask, vecf16_t a, vecf16_t b)  // CHECK: test_mixf:
 {
-	return __builtin_nyuzi_gather_loadf(ptr);
-
-	// CHECK: load_gath v{{[0-9]+}}, (v0)
+  return __builtin_nyuzi_vector_mixf(mask, a, b);
+  // CHECK: move_mask v{{[0-9]+}}, s0, v0
 }
 
-veci16_t test_gatherloadi_masked(veci16_t ptr, int mask) // CHECK: test_gatherloadi_masked
+veci16_t test_gatherloadi(veci16_t ptr)  // CHECK: test_gatherloadi
 {
-	return __builtin_nyuzi_gather_loadi_masked(ptr, mask);
+  return __builtin_nyuzi_gather_loadi(ptr);
 
-	// CHECK: load_gath_mask v{{[0-9]+}}, s0, (v0)
+  // CHECK: load_gath v{{[0-9]+}}, (v0)
 }
 
-vecf16_t test_gatherloadf_masked(veci16_t ptr, int mask) // CHECK: test_gatherloadf_masked
+vecf16_t test_gatherloadf(veci16_t ptr)  // CHECK: test_gatherloadf
 {
-	return __builtin_nyuzi_gather_loadf_masked(ptr, mask);
+  return __builtin_nyuzi_gather_loadf(ptr);
 
-	// CHECK: load_gath_mask v{{[0-9]+}}, s0, (v0)
+  // CHECK: load_gath v{{[0-9]+}}, (v0)
 }
 
-void test_scatter_storei(veci16_t ptr, veci16_t value) // CHECK: test_scatter_storei
+veci16_t test_gatherloadi_masked(veci16_t ptr,
+                                 int mask)  // CHECK: test_gatherloadi_masked
 {
-	__builtin_nyuzi_scatter_storei(ptr, value);
+  return __builtin_nyuzi_gather_loadi_masked(ptr, mask);
 
-	// CHECK: store_scat v1, (v0)
+  // CHECK: load_gath_mask v{{[0-9]+}}, s0, (v0)
 }
 
-void test_scatter_storef(veci16_t ptr, vecf16_t value) // CHECK: test_scatter_storef
+vecf16_t test_gatherloadf_masked(veci16_t ptr,
+                                 int mask)  // CHECK: test_gatherloadf_masked
 {
-	__builtin_nyuzi_scatter_storef(ptr, value);
+  return __builtin_nyuzi_gather_loadf_masked(ptr, mask);
 
-	// CHECK: store_scat v1, (v0)
+  // CHECK: load_gath_mask v{{[0-9]+}}, s0, (v0)
 }
 
-void test_scatter_storei_masked(veci16_t ptr, veci16_t value, int mask) // CHECK: test_scatter_storei_masked
+void test_scatter_storei(veci16_t ptr,
+                         veci16_t value)  // CHECK: test_scatter_storei
 {
-	__builtin_nyuzi_scatter_storei_masked(ptr, value, mask);
+  __builtin_nyuzi_scatter_storei(ptr, value);
 
-	// CHECK: store_scat_mask v1, s0, (v0)
+  // CHECK: store_scat v1, (v0)
 }
 
-void test_scatter_storef_masked(veci16_t ptr, vecf16_t value, int mask) // CHECK: test_scatter_storef_masked
+void test_scatter_storef(veci16_t ptr,
+                         vecf16_t value)  // CHECK: test_scatter_storef
 {
-	__builtin_nyuzi_scatter_storef_masked(ptr, value, mask);
+  __builtin_nyuzi_scatter_storef(ptr, value);
 
-	// CHECK: store_scat_mask v1, s0, (v0)
+  // CHECK: store_scat v1, (v0)
 }
 
-veci16_t test_block_loadi_masked(veci16_t *ptr, int mask)	// CHECK: test_block_loadi_masked:
+void test_scatter_storei_masked(veci16_t ptr, veci16_t value,
+                                int mask)  // CHECK: test_scatter_storei_masked
 {
-	return __builtin_nyuzi_block_loadi_masked(ptr, mask);
+  __builtin_nyuzi_scatter_storei_masked(ptr, value, mask);
 
-	// CHECK: load_v_mask v{{[0-9]+}}, s1, (s0)
+  // CHECK: store_scat_mask v1, s0, (v0)
 }
 
-vecf16_t test_block_loadf_masked(veci16_t *ptr, int mask)	// CHECK: test_block_loadf_masked:
+void test_scatter_storef_masked(veci16_t ptr, vecf16_t value,
+                                int mask)  // CHECK: test_scatter_storef_masked
 {
-	return __builtin_nyuzi_block_loadf_masked(ptr, mask);
+  __builtin_nyuzi_scatter_storef_masked(ptr, value, mask);
 
-	// CHECK: load_v_mask v{{[0-9]+}}, s1, (s0)
+  // CHECK: store_scat_mask v1, s0, (v0)
 }
 
-void test_block_storei_masked(veci16_t *ptr, veci16_t value, int mask) // CHECK: test_block_storei_masked:
+veci16_t test_block_loadi_masked(veci16_t *ptr,
+                                 int mask)  // CHECK: test_block_loadi_masked:
 {
-	__builtin_nyuzi_block_storei_masked(ptr, value, mask);
+  return __builtin_nyuzi_block_loadi_masked(ptr, mask);
 
-	// CHECK: store_v_mask v0, s1, (s0)
+  // CHECK: load_v_mask v{{[0-9]+}}, s1, (s0)
 }
 
-void test_block_storef_masked(veci16_t *ptr, vecf16_t value, int mask) // CHECK: test_block_storef_masked:
+vecf16_t test_block_loadf_masked(veci16_t *ptr,
+                                 int mask)  // CHECK: test_block_loadf_masked:
 {
-	__builtin_nyuzi_block_storef_masked(ptr, value, mask);
+  return __builtin_nyuzi_block_loadf_masked(ptr, mask);
 
-	// CHECK: store_v_mask v0, s1, (s0)
+  // CHECK: load_v_mask v{{[0-9]+}}, s1, (s0)
 }
 
-int test_clz(int value)	// CHECK: test_clz
+void test_block_storei_masked(veci16_t *ptr, veci16_t value,
+                              int mask)  // CHECK: test_block_storei_masked:
 {
-	return __builtin_clz(value);
+  __builtin_nyuzi_block_storei_masked(ptr, value, mask);
 
-	// CHECK: clz s0, s0
+  // CHECK: store_v_mask v0, s1, (s0)
 }
 
-int test_ctz(int value)	// CHECK: test_ctz
+void test_block_storef_masked(veci16_t *ptr, vecf16_t value,
+                              int mask)  // CHECK: test_block_storef_masked:
 {
-	return __builtin_ctz(value);
+  __builtin_nyuzi_block_storef_masked(ptr, value, mask);
 
-	// CHECK: ctz s0, s0
+  // CHECK: store_v_mask v0, s1, (s0)
 }
 
-int test_masked_cmpi_uge(veci16_t a, veci16_t b)	// CHECK: test_masked_cmpi_uge:
+int test_clz(int value)  // CHECK: test_clz
 {
-	return __builtin_nyuzi_mask_cmpi_uge(a, b);
-	// CHECK: cmpge_u s{{[0-9]+}}, v0, v1
+  return __builtin_clz(value);
+
+  // CHECK: clz s0, s0
 }
 
-int test_masked_cmpi_sge(veci16_t a, veci16_t b)	// CHECK: test_masked_cmpi_sge:
+int test_ctz(int value)  // CHECK: test_ctz
 {
-	return __builtin_nyuzi_mask_cmpi_sge(a, b);
-	// CHECK: cmpge_i s{{[0-9]+}}, v0, v1
+  return __builtin_ctz(value);
+
+  // CHECK: ctz s0, s0
 }
 
-int test_masked_cmpf_ge(vecf16_t a, vecf16_t b)	// CHECK: test_masked_cmpf_ge:
+int test_masked_cmpi_ugt(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_ugt:
 {
-	return __builtin_nyuzi_mask_cmpf_ge(a, b);
-	// CHECK: cmpge_f s{{[0-9]+}}, v0, v1
+  return __builtin_nyuzi_mask_cmpi_ugt(a, b);
+  // CHECK: cmpgt_u s{{[0-9]+}}, v0, v1
 }
 
-unsigned int test_builtin_frame_address() // CHECK: test_builtin_frame_address:
+int test_masked_cmpi_uge(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_uge:
 {
-	return __builtin_frame_address(0);
-	// CHECK: add_i sp, sp, -
-	// CHECK: store_32 fp,
-	// CHECK: move fp, sp
-	// CHECK: move s0, fp
+  return __builtin_nyuzi_mask_cmpi_uge(a, b);
+  // CHECK: cmpge_u s{{[0-9]+}}, v0, v1
 }
 
-unsigned int test_builtin_return_address() // CHECK: test_builtin_return_address:
+int test_masked_cmpi_ult(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_ult:
 {
-	return __builtin_return_address(0);
-	// CHECK: move s0, ra
+  return __builtin_nyuzi_mask_cmpi_ult(a, b);
+  // CHECK: cmplt_u s{{[0-9]+}}, v0, v1
 }
 
+int test_masked_cmpi_ule(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_ule:
+{
+  return __builtin_nyuzi_mask_cmpi_ule(a, b);
+  // CHECK: cmple_u s{{[0-9]+}}, v0, v1
+}
 
+int test_masked_cmpi_sgt(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_sgt:
+{
+  return __builtin_nyuzi_mask_cmpi_sgt(a, b);
+  // CHECK: cmpgt_i s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpi_sge(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_sge:
+{
+  return __builtin_nyuzi_mask_cmpi_sge(a, b);
+  // CHECK: cmpge_i s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpi_slt(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_slt:
+{
+  return __builtin_nyuzi_mask_cmpi_slt(a, b);
+  // CHECK: cmplt_i s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpi_sle(veci16_t a,
+                         veci16_t b)  // CHECK: test_masked_cmpi_sle:
+{
+  return __builtin_nyuzi_mask_cmpi_sle(a, b);
+  // CHECK: cmple_i s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpi_eq(veci16_t a, veci16_t b)  // CHECK: test_masked_cmpi_eq:
+{
+  return __builtin_nyuzi_mask_cmpi_eq(a, b);
+  // CHECK: cmpeq_i s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpi_ne(veci16_t a, veci16_t b)  // CHECK: test_masked_cmpi_ne:
+{
+  return __builtin_nyuzi_mask_cmpi_ne(a, b);
+  // CHECK: cmpne_i s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpf_gt(vecf16_t a, vecf16_t b)  // CHECK: test_masked_cmpf_gt:
+{
+  return __builtin_nyuzi_mask_cmpf_gt(a, b);
+  // CHECK: cmpgt_f s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpf_ge(vecf16_t a, vecf16_t b)  // CHECK: test_masked_cmpf_ge:
+{
+  return __builtin_nyuzi_mask_cmpf_ge(a, b);
+  // CHECK: cmpge_f s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpf_lt(vecf16_t a, vecf16_t b)  // CHECK: test_masked_cmpf_lt:
+{
+  return __builtin_nyuzi_mask_cmpf_lt(a, b);
+  // CHECK: cmplt_f s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpf_le(vecf16_t a, vecf16_t b)  // CHECK: test_masked_cmpf_le:
+{
+  return __builtin_nyuzi_mask_cmpf_le(a, b);
+  // CHECK: cmple_f s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpf_eq(vecf16_t a, vecf16_t b)  // CHECK: test_masked_cmpf_eq:
+{
+  return __builtin_nyuzi_mask_cmpf_eq(a, b);
+  // CHECK: cmpeq_f s{{[0-9]+}}, v0, v1
+}
+
+int test_masked_cmpf_ne(vecf16_t a, vecf16_t b)  // CHECK: test_masked_cmpf_ne:
+{
+  return __builtin_nyuzi_mask_cmpf_ne(a, b);
+  // CHECK: cmpne_f s{{[0-9]+}}, v0, v1
+}
+
+veci16_t test_shufflei(veci16_t lanes,
+                       veci16_t values)  // CHECK: test_shufflei:
+{
+  return __builtin_nyuzi_shufflei(lanes, values);
+  // CHECK: shuffle
+}
+
+vecf16_t test_shufflef(veci16_t lanes,
+                       vecf16_t values)  // CHECK: test_shufflef:
+{
+  return __builtin_nyuzi_shufflef(lanes, values);
+  // CHECK: shuffle
+}
+
+unsigned int test_builtin_frame_address()  // CHECK: test_builtin_frame_address:
+{
+  return __builtin_frame_address(0);
+  // CHECK: add_i sp, sp, -
+  // CHECK: store_32 fp,
+  // CHECK: move fp, sp
+  // CHECK: move s0, fp
+}
+
+unsigned int
+test_builtin_return_address()  // CHECK: test_builtin_return_address:
+{
+  return __builtin_return_address(0);
+  // CHECK: move s0, ra
+}

--- a/tools/spmd-compile/src/SPMDBuilder.h
+++ b/tools/spmd-compile/src/SPMDBuilder.h
@@ -55,6 +55,8 @@ public:
   llvm::Value *createConstant(float value);
 
   llvm::Type *sFloatType;
+  llvm::Type *sMaskType;
+  llvm::Type *sMaskIntType;
 
 private:
   struct MaskStackEntry {


### PR DESCRIPTION
This passes the lit Codegen tests and `make test` in the NyuziProcessor repository. (Except that I had to disable LLDB because my distro defaults to Python 3.)

Fixes #44 

PS: Apologies for the huge monolithic commit. If you want, I can try splitting it up, but this will be quite laborious and error-prone as the logical units of work overlap quite a bit in the diff.