### PR TITLE
Truncate i32 when lowering (constant) v16i1 BUILD_VECTOR

### DIFF
--- a/lib/Target/Nyuzi/NyuziISelLowering.cpp
+++ b/lib/Target/Nyuzi/NyuziISelLowering.cpp
@@ -828,7 +828,7 @@ SDValue NyuziTargetLowering::LowerBUILD_VECTOR(SDValue Op,
     uint64_t Bits = 0, LaneIndex = 0;
     for (auto Operand : Op.getNode()->op_values()) {
       if (auto C = dyn_cast<ConstantSDNode>(Operand)) {
-        Bits |= C->getZExtValue() << LaneIndex;
+        Bits |= (C->getZExtValue() & 1) << LaneIndex;
       } else {
         // Lane is undef, treat as 0. This might allow the
         // resulting value to fit into in an immediate operand.
@@ -844,8 +844,8 @@ SDValue NyuziTargetLowering::LowerBUILD_VECTOR(SDValue Op,
     // as in the constant case, so do insertions manually.
     SDValue Bitmask = DAG.getConstant(0, DL, MVT::i32);
     for (int i = 15; i >= 0; --i) {
-      // i1 is not legal, so the elements are i32.
-      // Additionally, the high bits may be undef (?)
+      // The elements may be arbitrary i32 values, truncate them
+      // (in accordance with the definition of BUILD_VECTOR).
       auto LaneBit = DAG.getNode(ISD::AND, DL, MVT::i32, Op.getOperand(i),
                                  DAG.getConstant(1, DL, MVT::i32));
       Bitmask = DAG.getNode(ISD::SHL, DL, MVT::i32, Bitmask,

--- a/test/CodeGen/Nyuzi/build-v16i1.ll
+++ b/test/CodeGen/Nyuzi/build-v16i1.ll
@@ -59,3 +59,13 @@ entry:
   %1 = insertelement <16 x i1> %0, i1 %b, i32 13
   ret <16 x i1> %1
 }
+
+; Checks that constant BUILD_VECTOR with i32 elements works
+; This is legal (elements of larger types are truncated),
+; but a bit hard to trigger, hence this weird function.
+define <16 x i1> @complicated_const_buildvector() { ; CHECK-LABEL: complicated_const_buildvector:
+  %a = icmp ult <16 x i32> zeroinitializer, <i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16>
+  %b = and <16 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>, %a
+  ; CHECK: load_32 s0, .LCPI
+  ret <16 x i1> %b
+}


### PR DESCRIPTION
The BUILD_VECTOR ISD node is documented to accept larger types as elements (e.g., building a v16i1 out of i32s) and truncate them.
This already worked for non-constants, but was missing in the code path for constants.