### PR TITLE
Enabled support for autovectorization. Closes #79.

### DIFF
--- a/lib/Target/Nyuzi/CMakeLists.txt
+++ b/lib/Target/Nyuzi/CMakeLists.txt
@@ -24,6 +24,7 @@ add_llvm_target(NyuziCodeGen
   NyuziTargetMachine.cpp
   NyuziMCInstLower.cpp
   NyuziTargetObjectFile.cpp
+  NyuziTargetTransformInfo.cpp
   )
 
 add_dependencies(LLVMNyuziCodeGen intrinsics_gen)

--- a/lib/Target/Nyuzi/NyuziTargetMachine.cpp
+++ b/lib/Target/Nyuzi/NyuziTargetMachine.cpp
@@ -14,6 +14,7 @@
 #include "MCTargetDesc/NyuziMCTargetDesc.h"
 #include "Nyuzi.h"
 #include "NyuziTargetObjectFile.h"
+#include "NyuziTargetTransformInfo.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -77,4 +78,8 @@ TargetPassConfig *NyuziTargetMachine::createPassConfig(PassManagerBase &PM) {
 bool NyuziPassConfig::addInstSelector() {
   addPass(createNyuziISelDag(getNyuziTargetMachine()));
   return false;
+}
+
+TargetTransformInfo NyuziTargetMachine::getTargetTransformInfo(const Function &F) {
+  return TargetTransformInfo(NyuziTTIImpl(this, F));
 }

--- a/lib/Target/Nyuzi/NyuziTargetMachine.h
+++ b/lib/Target/Nyuzi/NyuziTargetMachine.h
@@ -15,6 +15,7 @@
 #define LLVM_LIB_TARGET_NYUZI_NYUZITARGETMACHINE_H
 
 #include "NyuziSubtarget.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Target/TargetMachine.h"
 
 namespace llvm {
@@ -42,6 +43,8 @@ public:
   bool isMachineVerifierClean() const override {
     return false;
   }
+
+  TargetTransformInfo getTargetTransformInfo(const Function &F) override;
 };
 
 } // end namespace llvm

--- a/lib/Target/Nyuzi/NyuziTargetTransformInfo.cpp
+++ b/lib/Target/Nyuzi/NyuziTargetTransformInfo.cpp
@@ -1,0 +1,31 @@
+#include "NyuziTargetTransformInfo.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/CodeGen/BasicTTIImpl.h"
+using namespace llvm;
+
+unsigned NyuziTTIImpl::getNumberOfRegisters(bool Vec) const {
+  return 32;
+}
+
+unsigned NyuziTTIImpl::getRegisterBitWidth(bool Vector) const {
+  if (Vector)
+    return 512;
+  else
+    return 32;
+}
+
+unsigned NyuziTTIImpl::getMinVectorRegisterBitWidth() const {
+  return 512;
+}
+
+bool NyuziTTIImpl::shouldMaximizeVectorBandwidth(bool OptSize) const {
+  return false;
+}
+
+unsigned NyuziTTIImpl::getMaxInterleaveFactor(unsigned VF) const {
+  return 32;
+}
+
+bool NyuziTTIImpl::hasBranchDivergence() const {
+  return false;
+}

--- a/lib/Target/Nyuzi/NyuziTargetTransformInfo.h
+++ b/lib/Target/Nyuzi/NyuziTargetTransformInfo.h
@@ -1,0 +1,30 @@
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/CodeGen/BasicTTIImpl.h"
+#include "NyuziTargetMachine.h"
+
+namespace llvm {
+class NyuziTTIImpl final : public BasicTTIImplBase<NyuziTTIImpl> {
+  typedef BasicTTIImplBase<NyuziTTIImpl> BaseT;
+  typedef TargetTransformInfo TTI;
+  friend BaseT;
+
+  const NyuziSubtarget *ST;
+  const NyuziTargetLowering *TLI;
+
+  const NyuziSubtarget *getST() const { return ST; }
+  const NyuziTargetLowering *getTLI() const { return TLI; }
+
+public:
+  explicit NyuziTTIImpl(const NyuziTargetMachine *TM, const Function &F)
+    : BaseT(TM, F.getParent()->getDataLayout()),
+      ST(TM->getSubtargetImpl(F)),
+      TLI(ST->getTargetLowering()) {}
+
+  unsigned getNumberOfRegisters(bool Vector) const;
+  unsigned getRegisterBitWidth(bool Vector) const;
+  unsigned getMinVectorRegisterBitWidth() const;
+  bool shouldMaximizeVectorBandwidth(bool OptSize) const;
+  unsigned getMaxInterleaveFactor(unsigned VF) const;
+  bool hasBranchDivergence() const;
+};
+}

--- a/tools/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/tools/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4443,7 +4443,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                     options::OPT_fno_gnu_inline_asm, true))
     CmdArgs.push_back("-fno-gnu-inline-asm");
 
-#if 0
   // XXX Nyuzi: disable loop vectorizer by default, because it does not
   // work correctly on this target.  This is a hack. I couldn't find an
   // easy way to do it in the target.
@@ -4465,7 +4464,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasFlag(options::OPT_fslp_vectorize, SLPVectAliasOption,
                    options::OPT_fno_slp_vectorize, EnableSLPVec))
     CmdArgs.push_back("-vectorize-slp");
-#endif
 
   ParseMPreferVectorWidth(D, Args, CmdArgs);
 


### PR DESCRIPTION
- added NyuziTargetTransformInfo and implemented some required methods
- registered NyuziTargetTransformInfo in NyuziTargetMachine
- added NyuziTargetTransformInfo to CMakeLists in Nyuzi Target
- reactivated autovectorization in tools/clang/lib/Driver/ToolChains/Clang.cpp